### PR TITLE
Add React error boundaries for crash recovery

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -21,6 +21,7 @@ import {
 } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import Link from "next/link"
+import { ChartErrorBoundary } from "@/components/chart-error-boundary"
 import {
   BarChart,
   Bar,
@@ -185,20 +186,22 @@ export default function DashboardPage() {
           </CardHeader>
           <CardContent>
             {data.cashFlowByMonth.length > 0 ? (
-              <ResponsiveContainer width="100%" height={280}>
-                <BarChart data={data.cashFlowByMonth}>
-                  <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
-                  <XAxis dataKey="month" stroke="#71717a" fontSize={12} />
-                  <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${(v/1000).toFixed(0)}k`} />
-                  <Tooltip
-                    contentStyle={{ background: '#18181b', border: '1px solid #27272a', borderRadius: '8px' }}
-                    labelStyle={{ color: '#a1a1aa' }}
-                    formatter={(value) => formatCurrency(Number(value))}
-                  />
-                  <Bar dataKey="income" fill="#22c55e" radius={[4, 4, 0, 0]} name="Income" />
-                  <Bar dataKey="expenses" fill="#ef4444" radius={[4, 4, 0, 0]} name="Expenses" />
-                </BarChart>
-              </ResponsiveContainer>
+              <ChartErrorBoundary>
+                <ResponsiveContainer width="100%" height={280}>
+                  <BarChart data={data.cashFlowByMonth}>
+                    <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
+                    <XAxis dataKey="month" stroke="#71717a" fontSize={12} />
+                    <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${(v/1000).toFixed(0)}k`} />
+                    <Tooltip
+                      contentStyle={{ background: '#18181b', border: '1px solid #27272a', borderRadius: '8px' }}
+                      labelStyle={{ color: '#a1a1aa' }}
+                      formatter={(value) => formatCurrency(Number(value))}
+                    />
+                    <Bar dataKey="income" fill="#22c55e" radius={[4, 4, 0, 0]} name="Income" />
+                    <Bar dataKey="expenses" fill="#ef4444" radius={[4, 4, 0, 0]} name="Expenses" />
+                  </BarChart>
+                </ResponsiveContainer>
+              </ChartErrorBoundary>
             ) : (
               <div className="h-[280px] flex items-center justify-center text-zinc-500">
                 No data yet
@@ -215,27 +218,29 @@ export default function DashboardPage() {
           <CardContent>
             {data.topCategories.length > 0 ? (
               <div className="space-y-2">
-                <ResponsiveContainer width="100%" height={160}>
-                  <PieChart>
-                    <Pie
-                      data={data.topCategories.map(c => ({ name: c.name, value: Math.abs(c.total) }))}
-                      cx="50%"
-                      cy="50%"
-                      innerRadius={40}
-                      outerRadius={70}
-                      dataKey="value"
-                      stroke="none"
-                    >
-                      {data.topCategories.map((c, i) => (
-                        <Cell key={i} fill={c.color} />
-                      ))}
-                    </Pie>
-                    <Tooltip
-                      contentStyle={{ background: '#18181b', border: '1px solid #27272a', borderRadius: '8px' }}
-                      formatter={(value) => formatCurrency(Number(value))}
-                    />
-                  </PieChart>
-                </ResponsiveContainer>
+                <ChartErrorBoundary>
+                  <ResponsiveContainer width="100%" height={160}>
+                    <PieChart>
+                      <Pie
+                        data={data.topCategories.map(c => ({ name: c.name, value: Math.abs(c.total) }))}
+                        cx="50%"
+                        cy="50%"
+                        innerRadius={40}
+                        outerRadius={70}
+                        dataKey="value"
+                        stroke="none"
+                      >
+                        {data.topCategories.map((c, i) => (
+                          <Cell key={i} fill={c.color} />
+                        ))}
+                      </Pie>
+                      <Tooltip
+                        contentStyle={{ background: '#18181b', border: '1px solid #27272a', borderRadius: '8px' }}
+                        formatter={(value) => formatCurrency(Number(value))}
+                      />
+                    </PieChart>
+                  </ResponsiveContainer>
+                </ChartErrorBoundary>
                 <div className="space-y-2 mt-2">
                   {data.topCategories.map((cat, i) => (
                     <div key={i} className="flex items-center justify-between text-sm">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next"
 import "./globals.css"
 import { Sidebar } from "@/components/sidebar"
 import { ToastProvider } from "@/components/toast-provider"
+import { ErrorBoundary } from "@/components/error-boundary"
 
 export const metadata: Metadata = {
   title: "CashFlow - Personal Finance",
@@ -15,7 +16,9 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
         <Sidebar />
         <main className="md:ml-64 min-h-screen">
           <div className="p-6 md:p-8 max-w-7xl mx-auto">
-            {children}
+            <ErrorBoundary>
+              {children}
+            </ErrorBoundary>
           </div>
         </main>
         <ToastProvider />

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -13,6 +13,7 @@ import {
   PieChart, Pie, Cell, LineChart, Line, Legend, AreaChart, Area,
 } from "recharts"
 import { Badge } from "@/components/ui/badge"
+import { ChartErrorBoundary } from "@/components/chart-error-boundary"
 
 type ReportType = "spending-by-category" | "monthly-trends" | "income-vs-expenses" | "net-worth" | "year-over-year"
 
@@ -120,7 +121,7 @@ export default function ReportsPage() {
                 No data available for this report
               </div>
             ) : (
-              <>
+              <ChartErrorBoundary>
                 {reportType === "spending-by-category" && (
                   <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
                     <ResponsiveContainer width="100%" height={350}>
@@ -278,7 +279,7 @@ export default function ReportsPage() {
                     </div>
                   )
                 })()}
-              </>
+              </ChartErrorBoundary>
             )}
           </CardContent>
         </Card>

--- a/src/components/chart-error-boundary.tsx
+++ b/src/components/chart-error-boundary.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import React from "react"
+import { BarChart3 } from "lucide-react"
+
+interface ChartErrorBoundaryProps {
+  children: React.ReactNode
+}
+
+interface ChartErrorBoundaryState {
+  hasError: boolean
+}
+
+export class ChartErrorBoundary extends React.Component<ChartErrorBoundaryProps, ChartErrorBoundaryState> {
+  constructor(props: ChartErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false }
+  }
+
+  static getDerivedStateFromError(): ChartErrorBoundaryState {
+    return { hasError: true }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("Chart rendering error:", error, errorInfo)
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex flex-col items-center justify-center gap-2 py-8 text-muted-foreground">
+          <BarChart3 className="h-8 w-8" />
+          <p className="text-sm">Chart could not be rendered</p>
+        </div>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,0 +1,63 @@
+"use client"
+
+import React from "react"
+import { AlertCircle, RefreshCw } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent } from "@/components/ui/card"
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode
+  fallback?: React.ReactNode
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean
+  error: Error | null
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props)
+    this.state = { hasError: false, error: null }
+  }
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, error }
+  }
+
+  componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, errorInfo)
+  }
+
+  handleReset = () => {
+    this.setState({ hasError: false, error: null })
+  }
+
+  render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback
+      }
+
+      return (
+        <Card className="border-red-900/50 bg-red-950/20">
+          <CardContent className="flex flex-col items-center gap-4 py-8">
+            <AlertCircle className="h-10 w-10 text-red-400" />
+            <div className="text-center">
+              <h3 className="font-semibold text-red-400">Something went wrong</h3>
+              <p className="text-sm text-muted-foreground mt-1">
+                {this.state.error?.message || "An unexpected error occurred"}
+              </p>
+            </div>
+            <Button variant="outline" size="sm" onClick={this.handleReset}>
+              <RefreshCw className="h-4 w-4 mr-2" />
+              Try again
+            </Button>
+          </CardContent>
+        </Card>
+      )
+    }
+
+    return this.props.children
+  }
+}

--- a/src/lib/__tests__/error-boundary.test.ts
+++ b/src/lib/__tests__/error-boundary.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+
+// Test the error boundary logic without requiring a full DOM renderer.
+// We verify the class-based lifecycle methods directly.
+
+import { ErrorBoundary } from '@/components/error-boundary'
+import { ChartErrorBoundary } from '@/components/chart-error-boundary'
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('getDerivedStateFromError returns hasError true with the error', () => {
+    const error = new Error('test failure')
+    const state = ErrorBoundary.getDerivedStateFromError(error)
+    expect(state).toEqual({ hasError: true, error })
+  })
+
+  it('initial state has no error', () => {
+    const boundary = new ErrorBoundary({ children: null })
+    expect(boundary.state).toEqual({ hasError: false, error: null })
+  })
+
+  it('handleReset clears the error state', () => {
+    const boundary = new ErrorBoundary({ children: null })
+    boundary.state = { hasError: true, error: new Error('test') }
+    // Simulate setState by calling handleReset and checking it calls setState correctly
+    const setStateSpy = vi.fn()
+    boundary.setState = setStateSpy
+    boundary.handleReset()
+    expect(setStateSpy).toHaveBeenCalledWith({ hasError: false, error: null })
+  })
+
+  it('render returns children when no error', () => {
+    const boundary = new ErrorBoundary({ children: React.createElement('div', null, 'hello') })
+    boundary.state = { hasError: false, error: null }
+    const result = boundary.render()
+    expect(result).toEqual(React.createElement('div', null, 'hello'))
+  })
+
+  it('render returns fallback when provided and error exists', () => {
+    const fallback = React.createElement('span', null, 'fallback')
+    const boundary = new ErrorBoundary({ children: React.createElement('div'), fallback })
+    boundary.state = { hasError: true, error: new Error('crash') }
+    const result = boundary.render()
+    expect(result).toBe(fallback)
+  })
+
+  it('render returns default error UI when no fallback and error exists', () => {
+    const boundary = new ErrorBoundary({ children: React.createElement('div') })
+    boundary.state = { hasError: true, error: new Error('something broke') }
+    const result = boundary.render()
+    // Default error UI is a Card-based component (React element), not the children
+    expect(result).not.toEqual(React.createElement('div'))
+    expect(result).toBeTruthy()
+  })
+})
+
+describe('ChartErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('getDerivedStateFromError returns hasError true', () => {
+    const state = ChartErrorBoundary.getDerivedStateFromError()
+    expect(state).toEqual({ hasError: true })
+  })
+
+  it('initial state has no error', () => {
+    const boundary = new ChartErrorBoundary({ children: null })
+    expect(boundary.state).toEqual({ hasError: false })
+  })
+
+  it('render returns children when no error', () => {
+    const child = React.createElement('svg', null, 'chart')
+    const boundary = new ChartErrorBoundary({ children: child })
+    boundary.state = { hasError: false }
+    expect(boundary.render()).toEqual(child)
+  })
+
+  it('render returns fallback message when error exists', () => {
+    const boundary = new ChartErrorBoundary({ children: React.createElement('svg') })
+    boundary.state = { hasError: true }
+    const result = boundary.render()
+    expect(result).toBeTruthy()
+    expect(result).not.toEqual(React.createElement('svg'))
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `ErrorBoundary` component with a styled error card, error message display, and "Try again" reset button (supports optional custom `fallback` prop)
- Adds `ChartErrorBoundary` specifically for Recharts visualization failures with a lightweight fallback
- Wraps root layout `{children}` with `ErrorBoundary` so page-level crashes don't blank the entire app
- Wraps dashboard BarChart and PieChart with `ChartErrorBoundary`
- Wraps reports page chart rendering section with `ChartErrorBoundary`
- Adds 10 tests for boundary state management and lifecycle methods

## Test plan

- [x] All 112 tests pass (`npm test`)
- [x] `npx next build` succeeds
- [ ] Verify dashboard and reports pages render normally
- [ ] Verify error fallback appears when a chart component throws

Closes #13