### PR TITLE
Add database backup/restore and integrity checking

### DIFF
--- a/src/app/api/backup/route.ts
+++ b/src/app/api/backup/route.ts
@@ -1,0 +1,96 @@
+import { NextResponse } from 'next/server'
+import { getDb, getDbPath, closeDb } from '@/lib/db'
+import fs from 'fs'
+import path from 'path'
+import Database from 'better-sqlite3'
+
+export async function GET() {
+  try {
+    // Checkpoint WAL before backup to ensure all data is in the main DB file
+    const db = getDb()
+    db.pragma('wal_checkpoint(RESTART)')
+
+    const dbPath = getDbPath()
+    const fileBuffer = fs.readFileSync(dbPath)
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19)
+    const filename = `cashflow-backup-${timestamp}.db`
+
+    return new Response(fileBuffer, {
+      headers: {
+        'Content-Type': 'application/octet-stream',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Content-Length': String(fileBuffer.length),
+      },
+    })
+  } catch (error) {
+    console.error('Error creating backup:', error)
+    return NextResponse.json({ error: 'Failed to create backup' }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const formData = await request.formData()
+    const file = formData.get('file') as File | null
+
+    if (!file) {
+      return NextResponse.json({ error: 'No file provided' }, { status: 400 })
+    }
+
+    if (!file.name.endsWith('.db')) {
+      return NextResponse.json({ error: 'File must be a .db SQLite database' }, { status: 400 })
+    }
+
+    const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    // Validate the uploaded file is a valid SQLite database
+    const tempPath = path.join(process.cwd(), `restore-temp-${Date.now()}.db`)
+    try {
+      fs.writeFileSync(tempPath, buffer)
+      const testDb = new Database(tempPath, { readonly: true })
+      const integrity = testDb.pragma('integrity_check') as Array<{ integrity_check: string }>
+      const isValid = integrity.length > 0 && integrity[0].integrity_check === 'ok'
+
+      // Check that it has the expected tables
+      const tables = testDb.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>
+      const tableNames = tables.map(t => t.name)
+      const requiredTables = ['accounts', 'transactions', 'categories']
+      const missingTables = requiredTables.filter(t => !tableNames.includes(t))
+
+      testDb.close()
+
+      if (!isValid) {
+        fs.unlinkSync(tempPath)
+        return NextResponse.json({ error: 'Uploaded database failed integrity check' }, { status: 400 })
+      }
+
+      if (missingTables.length > 0) {
+        fs.unlinkSync(tempPath)
+        return NextResponse.json({ error: `Not a valid CashFlow database — missing tables: ${missingTables.join(', ')}` }, { status: 400 })
+      }
+    } catch (validationError) {
+      if (fs.existsSync(tempPath)) fs.unlinkSync(tempPath)
+      return NextResponse.json({ error: 'File is not a valid SQLite database' }, { status: 400 })
+    }
+
+    // Validation passed — replace the current database
+    const dbPath = getDbPath()
+    closeDb()
+
+    // Replace the database file
+    fs.copyFileSync(tempPath, dbPath)
+    fs.unlinkSync(tempPath)
+
+    // Remove WAL and SHM files if they exist
+    const walPath = dbPath + '-wal'
+    const shmPath = dbPath + '-shm'
+    if (fs.existsSync(walPath)) fs.unlinkSync(walPath)
+    if (fs.existsSync(shmPath)) fs.unlinkSync(shmPath)
+
+    return NextResponse.json({ success: true, message: 'Database restored. Please refresh the page.' })
+  } catch (error) {
+    console.error('Error restoring backup:', error)
+    return NextResponse.json({ error: 'Failed to restore backup' }, { status: 500 })
+  }
+}

--- a/src/app/api/database/route.ts
+++ b/src/app/api/database/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server'
+import { runCheckpoint, runVacuum, runIntegrityCheck } from '@/lib/db'
+
+export async function GET() {
+  try {
+    const integrity = runIntegrityCheck()
+    const isHealthy = integrity.length === 1 && integrity[0] === 'ok'
+
+    return NextResponse.json({
+      healthy: isHealthy,
+      integrity,
+    })
+  } catch (error) {
+    console.error('Error checking database health:', error)
+    return NextResponse.json({ error: 'Failed to check database health' }, { status: 500 })
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { action } = await request.json()
+
+    if (action === 'optimize') {
+      const checkpoint = runCheckpoint()
+      runVacuum()
+      return NextResponse.json({
+        success: true,
+        message: 'Database optimized',
+        checkpoint,
+      })
+    }
+
+    if (action === 'checkpoint') {
+      const checkpoint = runCheckpoint()
+      return NextResponse.json({
+        success: true,
+        message: 'WAL checkpoint completed',
+        checkpoint,
+      })
+    }
+
+    if (action === 'integrity-check') {
+      const results = runIntegrityCheck()
+      const isHealthy = results.length === 1 && results[0] === 'ok'
+      return NextResponse.json({
+        healthy: isHealthy,
+        results,
+      })
+    }
+
+    return NextResponse.json({ error: 'Unknown action' }, { status: 400 })
+  } catch (error) {
+    console.error('Error performing database action:', error)
+    return NextResponse.json({ error: 'Failed to perform database action' }, { status: 500 })
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Checkbox } from "@/components/ui/checkbox"
 import { formatDate } from "@/lib/utils"
-import { Plus, Trash2, Edit2, Building2, Tag, RefreshCw, Tags, Zap, Play, Pause, Sparkles, Check, X, Loader2 } from "lucide-react"
+import { Plus, Trash2, Edit2, Building2, Tag, RefreshCw, Tags, Zap, Play, Pause, Sparkles, Check, X, Loader2, Download, Upload, HardDrive, ShieldCheck } from "lucide-react"
 import { toast } from "sonner"
 
 interface Account {
@@ -78,6 +78,10 @@ export default function SettingsPage() {
   const [ruleActions, setRuleActions] = useState<RuleAction[]>([{ type: 'set_category', value: '' }])
   const [ruleApplyRetro, setRuleApplyRetro] = useState(true)
   const [applyingRules, setApplyingRules] = useState(false)
+  const [optimizing, setOptimizing] = useState(false)
+  const [dbHealthy, setDbHealthy] = useState<boolean | null>(null)
+  const [checkingHealth, setCheckingHealth] = useState(false)
+  const [restoring, setRestoring] = useState(false)
 
   const fetchData = () => {
     fetch("/api/accounts").then(r => r.json()).then(d => setAccounts(d.accounts || []))
@@ -343,6 +347,80 @@ export default function SettingsPage() {
     }
   }
 
+  const downloadBackup = async () => {
+    try {
+      const res = await fetch("/api/backup")
+      if (!res.ok) throw new Error("Backup failed")
+      const blob = await res.blob()
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement("a")
+      a.href = url
+      const disposition = res.headers.get("Content-Disposition") || ""
+      const match = disposition.match(/filename="(.+)"/)
+      a.download = match ? match[1] : "cashflow-backup.db"
+      a.click()
+      URL.revokeObjectURL(url)
+      toast.success("Backup downloaded")
+    } catch {
+      toast.error("Failed to create backup")
+    }
+  }
+
+  const restoreBackup = async (file: File) => {
+    setRestoring(true)
+    try {
+      const formData = new FormData()
+      formData.append("file", file)
+      const res = await fetch("/api/backup", { method: "POST", body: formData })
+      const data = await res.json()
+      if (!res.ok) {
+        toast.error(data.error || "Failed to restore backup")
+        return
+      }
+      toast.success("Database restored. Refreshing...")
+      setTimeout(() => window.location.reload(), 1500)
+    } catch {
+      toast.error("Failed to restore backup")
+    } finally {
+      setRestoring(false)
+    }
+  }
+
+  const optimizeDatabase = async () => {
+    setOptimizing(true)
+    try {
+      const res = await fetch("/api/database", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "optimize" }),
+      })
+      if (!res.ok) throw new Error()
+      toast.success("Database optimized")
+    } catch {
+      toast.error("Failed to optimize database")
+    } finally {
+      setOptimizing(false)
+    }
+  }
+
+  const checkDatabaseHealth = async () => {
+    setCheckingHealth(true)
+    try {
+      const res = await fetch("/api/database")
+      const data = await res.json()
+      setDbHealthy(data.healthy)
+      if (data.healthy) {
+        toast.success("Database integrity check passed")
+      } else {
+        toast.error("Database integrity issues detected")
+      }
+    } catch {
+      toast.error("Failed to check database health")
+    } finally {
+      setCheckingHealth(false)
+    }
+  }
+
   const operatorLabels: Record<string, string> = {
     contains: 'contains', starts_with: 'starts with', ends_with: 'ends with',
     equals: 'equals', regex: 'matches regex',
@@ -575,6 +653,66 @@ export default function SettingsPage() {
               ))}
             </div>
           )}
+        </CardContent>
+      </Card>
+
+      {/* Database Management */}
+      <Card>
+        <CardHeader>
+          <div>
+            <CardTitle className="flex items-center gap-2"><HardDrive className="h-5 w-5" /> Database Management</CardTitle>
+            <CardDescription>Backup, restore, and optimize your database</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div className="p-4 rounded-lg bg-zinc-800/30 space-y-2">
+              <h3 className="text-sm font-medium text-zinc-200">Backup & Restore</h3>
+              <p className="text-xs text-zinc-500">Download a copy of your database or restore from a previous backup.</p>
+              <div className="flex gap-2 pt-1">
+                <Button variant="outline" size="sm" onClick={downloadBackup}>
+                  <Download className="h-4 w-4 mr-1" /> Export Backup
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  disabled={restoring}
+                  onClick={() => {
+                    const input = document.createElement("input")
+                    input.type = "file"
+                    input.accept = ".db"
+                    input.onchange = (e) => {
+                      const file = (e.target as HTMLInputElement).files?.[0]
+                      if (file) restoreBackup(file)
+                    }
+                    input.click()
+                  }}
+                >
+                  {restoring ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <Upload className="h-4 w-4 mr-1" />}
+                  Restore Backup
+                </Button>
+              </div>
+            </div>
+            <div className="p-4 rounded-lg bg-zinc-800/30 space-y-2">
+              <h3 className="text-sm font-medium text-zinc-200">Maintenance</h3>
+              <p className="text-xs text-zinc-500">Optimize reclaims unused space. Health check verifies data integrity.</p>
+              <div className="flex gap-2 pt-1">
+                <Button variant="outline" size="sm" onClick={optimizeDatabase} disabled={optimizing}>
+                  {optimizing ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <RefreshCw className="h-4 w-4 mr-1" />}
+                  Optimize
+                </Button>
+                <Button variant="outline" size="sm" onClick={checkDatabaseHealth} disabled={checkingHealth}>
+                  {checkingHealth ? <Loader2 className="h-4 w-4 mr-1 animate-spin" /> : <ShieldCheck className="h-4 w-4 mr-1" />}
+                  Health Check
+                  {dbHealthy !== null && (
+                    <Badge variant={dbHealthy ? "success" : "destructive"} className="ml-2 text-xs">
+                      {dbHealthy ? "OK" : "Issues"}
+                    </Badge>
+                  )}
+                </Button>
+              </div>
+            </div>
+          </div>
         </CardContent>
       </Card>
 

--- a/src/lib/__tests__/db-maintenance.test.ts
+++ b/src/lib/__tests__/db-maintenance.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import Database from 'better-sqlite3'
+
+describe('database maintenance utilities', () => {
+  let db: Database.Database
+
+  beforeEach(() => {
+    db = new Database(':memory:')
+    db.pragma('journal_mode = WAL')
+    db.exec(`
+      CREATE TABLE accounts (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+      CREATE TABLE transactions (id TEXT PRIMARY KEY, account_id TEXT, amount REAL);
+      CREATE TABLE categories (id TEXT PRIMARY KEY, name TEXT NOT NULL);
+    `)
+  })
+
+  afterEach(() => {
+    if (db) db.close()
+  })
+
+  describe('integrity check', () => {
+    it('returns ok for a healthy database', () => {
+      const results = db.pragma('integrity_check') as Array<{ integrity_check: string }>
+      expect(results).toHaveLength(1)
+      expect(results[0].integrity_check).toBe('ok')
+    })
+
+    it('returns ok after inserting data', () => {
+      db.prepare("INSERT INTO accounts (id, name) VALUES ('a1', 'Checking')").run()
+      db.prepare("INSERT INTO transactions (id, account_id, amount) VALUES ('t1', 'a1', -50.25)").run()
+      const results = db.pragma('integrity_check') as Array<{ integrity_check: string }>
+      expect(results[0].integrity_check).toBe('ok')
+    })
+  })
+
+  describe('WAL checkpoint', () => {
+    it('executes wal_checkpoint without error', () => {
+      db.prepare("INSERT INTO accounts (id, name) VALUES ('a1', 'Test')").run()
+      const result = db.pragma('wal_checkpoint(RESTART)') as Array<{ busy: number; log: number; checkpointed: number }>
+      expect(result).toHaveLength(1)
+      expect(result[0]).toHaveProperty('busy')
+      expect(result[0]).toHaveProperty('log')
+      expect(result[0]).toHaveProperty('checkpointed')
+    })
+  })
+
+  describe('VACUUM', () => {
+    it('executes vacuum without error', () => {
+      db.prepare("INSERT INTO accounts (id, name) VALUES ('a1', 'Test')").run()
+      db.prepare("DELETE FROM accounts WHERE id = 'a1'").run()
+      expect(() => db.exec('VACUUM')).not.toThrow()
+    })
+  })
+
+  describe('backup validation', () => {
+    it('validates that required tables exist', () => {
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>
+      const tableNames = tables.map(t => t.name)
+      expect(tableNames).toContain('accounts')
+      expect(tableNames).toContain('transactions')
+      expect(tableNames).toContain('categories')
+    })
+
+    it('detects missing tables in an invalid database', () => {
+      const emptyDb = new Database(':memory:')
+      emptyDb.exec("CREATE TABLE other (id TEXT)")
+      const tables = emptyDb.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>
+      const tableNames = tables.map(t => t.name)
+      const requiredTables = ['accounts', 'transactions', 'categories']
+      const missing = requiredTables.filter(t => !tableNames.includes(t))
+      expect(missing).toEqual(['accounts', 'transactions', 'categories'])
+      emptyDb.close()
+    })
+
+    it('accepts a valid CashFlow database copy', () => {
+      db.prepare("INSERT INTO accounts (id, name) VALUES ('a1', 'Checking')").run()
+      db.prepare("INSERT INTO categories (id, name) VALUES ('c1', 'Food')").run()
+
+      // Simulate validation: check integrity and tables
+      const integrity = db.pragma('integrity_check') as Array<{ integrity_check: string }>
+      expect(integrity[0].integrity_check).toBe('ok')
+
+      const tables = db.prepare("SELECT name FROM sqlite_master WHERE type='table'").all() as Array<{ name: string }>
+      const tableNames = tables.map(t => t.name)
+      expect(tableNames).toContain('accounts')
+      expect(tableNames).toContain('transactions')
+      expect(tableNames).toContain('categories')
+    })
+  })
+})

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -11,8 +11,44 @@ export function getDb(): Database.Database {
     db.pragma('journal_mode = WAL')
     db.pragma('foreign_keys = ON')
     initializeSchema(db)
+    // Checkpoint WAL on startup to keep WAL file size bounded
+    db.pragma('wal_checkpoint(RESTART)')
+    // Run integrity check on startup and log any issues
+    const integrityResult = db.pragma('integrity_check') as Array<{ integrity_check: string }>
+    if (integrityResult.length > 0 && integrityResult[0].integrity_check !== 'ok') {
+      console.error('Database integrity check failed:', integrityResult)
+    }
   }
   return db
+}
+
+export function getDbPath(): string {
+  return DB_PATH
+}
+
+export function closeDb(): void {
+  if (db) {
+    db.close()
+    db = null
+  }
+}
+
+export function runCheckpoint(): { walPages: number; checkpointed: number } {
+  const db = getDb()
+  const result = db.pragma('wal_checkpoint(RESTART)') as Array<{ busy: number; log: number; checkpointed: number }>
+  const row = result[0] || { log: 0, checkpointed: 0 }
+  return { walPages: row.log, checkpointed: row.checkpointed }
+}
+
+export function runVacuum(): void {
+  const db = getDb()
+  db.exec('VACUUM')
+}
+
+export function runIntegrityCheck(): string[] {
+  const db = getDb()
+  const results = db.pragma('integrity_check') as Array<{ integrity_check: string }>
+  return results.map(r => r.integrity_check)
 }
 
 function initializeSchema(db: Database.Database) {


### PR DESCRIPTION
## Summary

- Adds WAL checkpoint and integrity check on app startup to keep the database healthy
- New `/api/backup` endpoints: GET downloads a timestamped `.db` file, POST accepts a `.db` upload with validation (integrity check + required table verification) before replacing the database
- New `/api/database` endpoints: GET returns health status, POST supports `optimize` (checkpoint + vacuum), `checkpoint`, and `integrity-check` actions
- New "Database Management" card in Settings with Export Backup, Restore Backup, Optimize, and Health Check buttons
- Adds `closeDb`, `runCheckpoint`, `runVacuum`, `runIntegrityCheck` exports from `db.ts`
- 7 new tests for integrity check, WAL checkpoint, vacuum, and backup validation logic

## Test plan

- [x] All 109 tests pass (`npm test`)
- [x] `npx next build` succeeds
- [ ] Verify Export Backup downloads a valid `.db` file
- [ ] Verify Restore Backup validates and rejects non-SQLite files
- [ ] Verify Optimize and Health Check buttons work correctly

Closes #14