### PR TITLE
Improve accessibility: ARIA labels, keyboard nav, semantic HTML

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,8 +12,14 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en" className="dark">
       <body className="min-h-screen bg-background text-foreground antialiased">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium"
+        >
+          Skip to main content
+        </a>
         <Sidebar />
-        <main className="md:ml-64 min-h-screen">
+        <main id="main-content" className="md:ml-64 min-h-screen">
           <div className="p-6 md:p-8 max-w-7xl mx-auto">
             {children}
           </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -392,11 +392,11 @@ export default function SettingsPage() {
                   </div>
                   <div className="flex items-center gap-2">
                     <Badge variant="secondary" className="capitalize">{acc.type}</Badge>
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => editAccount(acc)}>
-                      <Edit2 className="h-3 w-3" />
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => editAccount(acc)} aria-label={`Edit ${acc.name}`}>
+                      <Edit2 className="h-3 w-3" aria-hidden="true" />
                     </Button>
-                    <Button variant="ghost" size="icon" className="h-7 w-7 text-red-400" onClick={() => setDeletingAccount(acc)}>
-                      <Trash2 className="h-3 w-3" />
+                    <Button variant="ghost" size="icon" className="h-7 w-7 text-red-400" onClick={() => setDeletingAccount(acc)} aria-label={`Delete ${acc.name}`}>
+                      <Trash2 className="h-3 w-3" aria-hidden="true" />
                     </Button>
                   </div>
                 </div>
@@ -446,11 +446,11 @@ export default function SettingsPage() {
                   </div>
                   <div className="flex items-center gap-3 ml-4">
                     <span className="text-xs text-zinc-600">{alias.match_count} matches</span>
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => editAlias(alias)}>
-                      <Edit2 className="h-3 w-3" />
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => editAlias(alias)} aria-label={`Edit ${alias.display_name}`}>
+                      <Edit2 className="h-3 w-3" aria-hidden="true" />
                     </Button>
-                    <Button variant="ghost" size="icon" className="h-7 w-7 text-red-400" onClick={() => deleteAlias(alias.id)}>
-                      <Trash2 className="h-3 w-3" />
+                    <Button variant="ghost" size="icon" className="h-7 w-7 text-red-400" onClick={() => deleteAlias(alias.id)} aria-label={`Delete ${alias.display_name}`}>
+                      <Trash2 className="h-3 w-3" aria-hidden="true" />
                     </Button>
                   </div>
                 </div>
@@ -488,16 +488,18 @@ export default function SettingsPage() {
                     size="icon"
                     className="h-5 w-5 opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={() => { setTagForm({ id: tag.id, name: tag.name, color: tag.color }); setShowTagDialog(true) }}
+                    aria-label={`Edit ${tag.name}`}
                   >
-                    <Edit2 className="h-2.5 w-2.5" />
+                    <Edit2 className="h-2.5 w-2.5" aria-hidden="true" />
                   </Button>
                   <Button
                     variant="ghost"
                     size="icon"
                     className="h-5 w-5 text-red-400 opacity-0 group-hover:opacity-100 transition-opacity"
                     onClick={() => deleteTag(tag.id)}
+                    aria-label={`Delete ${tag.name}`}
                   >
-                    <Trash2 className="h-2.5 w-2.5" />
+                    <Trash2 className="h-2.5 w-2.5" aria-hidden="true" />
                   </Button>
                 </div>
               ))}
@@ -561,14 +563,14 @@ export default function SettingsPage() {
                   </div>
                   <div className="flex items-center gap-2 ml-4">
                     <span className="text-xs text-zinc-600">{rule.match_count} matches</span>
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => toggleRule(rule)}>
-                      {rule.is_active ? <Pause className="h-3 w-3" /> : <Play className="h-3 w-3" />}
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => toggleRule(rule)} aria-label={rule.is_active ? `Disable ${rule.name}` : `Enable ${rule.name}`}>
+                      {rule.is_active ? <Pause className="h-3 w-3" aria-hidden="true" /> : <Play className="h-3 w-3" aria-hidden="true" />}
                     </Button>
-                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => editRule(rule)}>
-                      <Edit2 className="h-3 w-3" />
+                    <Button variant="ghost" size="icon" className="h-7 w-7" onClick={() => editRule(rule)} aria-label={`Edit ${rule.name}`}>
+                      <Edit2 className="h-3 w-3" aria-hidden="true" />
                     </Button>
-                    <Button variant="ghost" size="icon" className="h-7 w-7 text-red-400" onClick={() => deleteRule(rule.id)}>
-                      <Trash2 className="h-3 w-3" />
+                    <Button variant="ghost" size="icon" className="h-7 w-7 text-red-400" onClick={() => deleteRule(rule.id)} aria-label={`Delete ${rule.name}`}>
+                      <Trash2 className="h-3 w-3" aria-hidden="true" />
                     </Button>
                   </div>
                 </div>
@@ -862,8 +864,9 @@ export default function SettingsPage() {
                     )}
                     {ruleConditions.length > 1 && (
                       <Button variant="ghost" size="icon" className="h-10 w-10 shrink-0 text-red-400"
-                        onClick={() => setRuleConditions(ruleConditions.filter((_, j) => j !== i))}>
-                        <Trash2 className="h-3 w-3" />
+                        onClick={() => setRuleConditions(ruleConditions.filter((_, j) => j !== i))}
+                        aria-label={`Remove condition ${i + 1}`}>
+                        <Trash2 className="h-3 w-3" aria-hidden="true" />
                       </Button>
                     )}
                   </div>
@@ -936,8 +939,9 @@ export default function SettingsPage() {
                     )}
                     {ruleActions.length > 1 && (
                       <Button variant="ghost" size="icon" className="h-10 w-10 shrink-0 text-red-400"
-                        onClick={() => setRuleActions(ruleActions.filter((_, j) => j !== i))}>
-                        <Trash2 className="h-3 w-3" />
+                        onClick={() => setRuleActions(ruleActions.filter((_, j) => j !== i))}
+                        aria-label={`Remove action ${i + 1}`}>
+                        <Trash2 className="h-3 w-3" aria-hidden="true" />
                       </Button>
                     )}
                   </div>

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -40,6 +40,8 @@ export function Sidebar() {
       <button
         onClick={() => setMobileOpen(!mobileOpen)}
         className="fixed top-4 left-4 z-50 md:hidden p-2 rounded-lg bg-zinc-800 text-zinc-300"
+        aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
+        aria-expanded={mobileOpen}
       >
         {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
       </button>
@@ -66,7 +68,7 @@ export function Sidebar() {
           <p className="text-xs text-zinc-500 mt-1">Personal Finance</p>
         </div>
 
-        <nav className="flex-1 p-4 space-y-1">
+        <nav className="flex-1 p-4 space-y-1" aria-label="Main navigation">
           {navItems.map((item) => {
             const isActive = pathname === item.href || pathname?.startsWith(item.href + "/")
             return (
@@ -74,6 +76,7 @@ export function Sidebar() {
                 key={item.href}
                 href={item.href}
                 onClick={() => setMobileOpen(false)}
+                aria-current={isActive ? "page" : undefined}
                 className={cn(
                   "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
                   isActive
@@ -81,7 +84,7 @@ export function Sidebar() {
                     : "text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/50"
                 )}
               >
-                <item.icon className="h-4 w-4" />
+                <item.icon className="h-4 w-4" aria-hidden="true" />
                 {item.label}
               </Link>
             )

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -37,8 +37,8 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 text-zinc-400">
-        <X className="h-4 w-4" />
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 text-zinc-400" aria-label="Close">
+        <X className="h-4 w-4" aria-hidden="true" />
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -7,21 +7,28 @@ interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
 }
 
 const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
-  ({ className, value = 0, indicatorColor, ...props }, ref) => (
-    <div
-      ref={ref}
-      className={cn("relative h-3 w-full overflow-hidden rounded-full bg-zinc-800", className)}
-      {...props}
-    >
+  ({ className, value = 0, indicatorColor, ...props }, ref) => {
+    const clampedValue = Math.min(Math.max(value, 0), 100)
+    return (
       <div
-        className="h-full rounded-full transition-all duration-500 ease-out"
-        style={{
-          width: `${Math.min(Math.max(value, 0), 100)}%`,
-          backgroundColor: indicatorColor || (value > 90 ? '#EF4444' : value > 75 ? '#F59E0B' : '#22C55E'),
-        }}
-      />
-    </div>
-  )
+        ref={ref}
+        role="progressbar"
+        aria-valuenow={Math.round(clampedValue)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+        className={cn("relative h-3 w-full overflow-hidden rounded-full bg-zinc-800", className)}
+        {...props}
+      >
+        <div
+          className="h-full rounded-full transition-all duration-500 ease-out"
+          style={{
+            width: `${clampedValue}%`,
+            backgroundColor: indicatorColor || (value > 90 ? '#EF4444' : value > 75 ? '#F59E0B' : '#22C55E'),
+          }}
+        />
+      </div>
+    )
+  }
 )
 Progress.displayName = "Progress"
 

--- a/src/lib/__tests__/accessibility.test.ts
+++ b/src/lib/__tests__/accessibility.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+
+function readComponent(relativePath: string): string {
+  return fs.readFileSync(path.resolve(__dirname, '../../', relativePath), 'utf-8')
+}
+
+describe('Accessibility: ARIA attributes and semantic HTML', () => {
+  describe('Sidebar', () => {
+    const source = readComponent('components/sidebar.tsx')
+
+    it('has aria-label on mobile toggle button', () => {
+      expect(source).toContain('aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}')
+    })
+
+    it('has aria-expanded on mobile toggle button', () => {
+      expect(source).toContain('aria-expanded={mobileOpen}')
+    })
+
+    it('has aria-label on nav element', () => {
+      expect(source).toContain('aria-label="Main navigation"')
+    })
+
+    it('has aria-current on active nav links', () => {
+      expect(source).toContain('aria-current={isActive ? "page" : undefined}')
+    })
+
+    it('has aria-hidden on nav icons', () => {
+      expect(source).toContain('<item.icon className="h-4 w-4" aria-hidden="true" />')
+    })
+  })
+
+  describe('Dialog', () => {
+    const source = readComponent('components/ui/dialog.tsx')
+
+    it('has aria-label on close button', () => {
+      expect(source).toContain('aria-label="Close"')
+    })
+
+    it('has aria-hidden on close icon', () => {
+      expect(source).toContain('aria-hidden="true"')
+    })
+  })
+
+  describe('Progress', () => {
+    const source = readComponent('components/ui/progress.tsx')
+
+    it('has role="progressbar"', () => {
+      expect(source).toContain('role="progressbar"')
+    })
+
+    it('has aria-valuenow', () => {
+      expect(source).toContain('aria-valuenow={Math.round(clampedValue)}')
+    })
+
+    it('has aria-valuemin and aria-valuemax', () => {
+      expect(source).toContain('aria-valuemin={0}')
+      expect(source).toContain('aria-valuemax={100}')
+    })
+  })
+
+  describe('Layout', () => {
+    const source = readComponent('app/layout.tsx')
+
+    it('has skip-to-content link', () => {
+      expect(source).toContain('href="#main-content"')
+      expect(source).toContain('Skip to main content')
+    })
+
+    it('has main-content id on main element', () => {
+      expect(source).toContain('id="main-content"')
+    })
+  })
+
+  describe('Settings page icon buttons', () => {
+    const source = readComponent('app/settings/page.tsx')
+
+    it('account edit buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Edit ${acc.name}`}')
+    })
+
+    it('account delete buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Delete ${acc.name}`}')
+    })
+
+    it('alias edit buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Edit ${alias.display_name}`}')
+    })
+
+    it('alias delete buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Delete ${alias.display_name}`}')
+    })
+
+    it('tag edit buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Edit ${tag.name}`}')
+    })
+
+    it('tag delete buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Delete ${tag.name}`}')
+    })
+
+    it('rule toggle buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={rule.is_active ? `Disable ${rule.name}` : `Enable ${rule.name}`}')
+    })
+
+    it('rule edit buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Edit ${rule.name}`}')
+    })
+
+    it('rule delete buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Delete ${rule.name}`}')
+    })
+
+    it('condition remove buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Remove condition ${i + 1}`}')
+    })
+
+    it('action remove buttons have aria-labels', () => {
+      expect(source).toContain('aria-label={`Remove action ${i + 1}`}')
+    })
+
+    it('all icon-only buttons have aria-hidden on icons', () => {
+      // Every Trash2 and Edit2 inside icon buttons should have aria-hidden
+      const editIconMatches = source.match(/<Edit2[^/]*\/>/g) || []
+      for (const match of editIconMatches) {
+        expect(match).toContain('aria-hidden="true"')
+      }
+      const trashIconMatches = source.match(/<Trash2[^/]*\/>/g) || []
+      for (const match of trashIconMatches) {
+        expect(match).toContain('aria-hidden="true"')
+      }
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- **Sidebar**: Added `aria-label`/`aria-expanded` on mobile toggle, `aria-label="Main navigation"` on `<nav>`, `aria-current="page"` on active links, `aria-hidden` on decorative icons
- **Dialog**: Added `aria-label="Close"` on close button with `aria-hidden` on X icon
- **Progress bar**: Added `role="progressbar"` with `aria-valuenow`, `aria-valuemin`, `aria-valuemax`
- **Layout**: Added skip-to-content link and `id="main-content"` landmark on `<main>`
- **Settings page**: Added descriptive `aria-label` on all 11 icon-only button patterns (edit, delete, toggle, remove condition/action) with `aria-hidden` on decorative icons

## Test plan
- [x] 24 new tests in `accessibility.test.ts` verify all ARIA attributes
- [x] All 126 tests pass (`npm test`)
- [x] `npx next build` succeeds

Closes #11