### PR TITLE
Add shared TypeScript interfaces for API responses

### DIFF
--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -14,12 +14,13 @@ import {
 } from "recharts"
 import { Badge } from "@/components/ui/badge"
 import { ChartErrorBoundary } from "@/components/chart-error-boundary"
+import type { ReportResponse, IncomeVsExpensesMonth, YearOverYearData } from "@/lib/types"
 
 type ReportType = "spending-by-category" | "monthly-trends" | "income-vs-expenses" | "net-worth" | "year-over-year"
 
 export default function ReportsPage() {
   const [reportType, setReportType] = useState<ReportType>("spending-by-category")
-  const [rawData, setRawData] = useState<any>(null)
+  const [rawData, setRawData] = useState<ReportResponse | null>(null)
   const [loading, setLoading] = useState(true)
   const [startDate, setStartDate] = useState("")
   const [endDate, setEndDate] = useState("")
@@ -36,10 +37,10 @@ export default function ReportsPage() {
   }, [reportType, startDate, endDate])
 
   const exportCSV = () => {
-    if (!rawData?.data?.length) return
-    const rows = rawData.data
+    if (!rawData || !('data' in rawData) || !rawData.data?.length) return
+    const rows = rawData.data as Record<string, unknown>[]
     const keys = Object.keys(rows[0] || {})
-    const csv = [keys.join(","), ...rows.map((r: any) => keys.map((k) => JSON.stringify(r[k] ?? "")).join(","))].join("\n")
+    const csv = [keys.join(","), ...rows.map((r) => keys.map((k) => JSON.stringify(r[k] ?? "")).join(","))].join("\n")
     const blob = new Blob([csv], { type: "text/csv" })
     const url = URL.createObjectURL(blob)
     const a = document.createElement("a")
@@ -51,18 +52,19 @@ export default function ReportsPage() {
 
   const COLORS = ["#EF4444", "#3B82F6", "#22C55E", "#F59E0B", "#8B5CF6", "#EC4899", "#14B8A6", "#F97316", "#6366F1", "#06B6D4"]
 
-  const hasData = rawData?.data?.length > 0
+  const hasData = rawData && 'data' in rawData && Array.isArray(rawData.data) && rawData.data.length > 0
 
   // Transform monthly-trends data into flat rows for Recharts
   const getTrendData = () => {
-    if (!rawData?.data) return { rows: [], categories: [] as string[] }
+    if (!rawData || !('data' in rawData)) return { rows: [] as Record<string, string | number>[], categories: [] as string[] }
+    const data = rawData.data as Array<{ month: string; categories?: Array<{ name: string; total: number }> }>
     const catSet = new Set<string>()
-    rawData.data.forEach((m: any) => m.categories?.forEach((c: any) => catSet.add(c.name)))
+    data.forEach((m) => m.categories?.forEach((c) => catSet.add(c.name)))
     const categories = Array.from(catSet)
-    const rows = rawData.data.map((m: any) => {
-      const row: any = { month: m.month }
+    const rows = data.map((m) => {
+      const row: Record<string, string | number> = { month: m.month }
       categories.forEach(c => { row[c] = 0 })
-      m.categories?.forEach((c: any) => { row[c.name] = c.total })
+      m.categories?.forEach((c) => { row[c.name] = c.total })
       return row
     })
     return { rows, categories }
@@ -70,8 +72,9 @@ export default function ReportsPage() {
 
   // Transform net-worth data
   const getNetWorthData = () => {
-    if (!rawData?.data) return []
-    return rawData.data.map((m: any) => ({ month: m.month, ...m.balances, total: m.total }))
+    if (!rawData || !('data' in rawData)) return []
+    const data = rawData.data as Array<{ month: string; balances: Record<string, number>; total: number }>
+    return data.map((m) => ({ month: m.month, ...m.balances, total: m.total }))
   }
 
   return (
@@ -127,12 +130,12 @@ export default function ReportsPage() {
                     <ResponsiveContainer width="100%" height={350}>
                       <PieChart>
                         <Pie
-                          data={rawData.data.map((r: any) => ({ name: r.name, value: Math.abs(r.total) }))}
+                          data={(rawData!.data as Array<{ name: string; total: number }>).map((r) => ({ name: r.name, value: Math.abs(r.total) }))}
                           cx="50%" cy="50%" innerRadius={60} outerRadius={130}
                           dataKey="value" stroke="none"
-                          label={({ name, percent }: any) => `${name} ${(percent * 100).toFixed(0)}%`}
+                          label={({ name, percent }: { name?: string; percent?: number }) => `${name ?? ''} ${((percent ?? 0) * 100).toFixed(0)}%`}
                         >
-                          {rawData.data.map((r: any, i: number) => (
+                          {(rawData!.data as Array<{ color?: string }>).map((r, i: number) => (
                             <Cell key={i} fill={r.color || COLORS[i % COLORS.length]} />
                           ))}
                         </Pie>
@@ -143,7 +146,7 @@ export default function ReportsPage() {
                       </PieChart>
                     </ResponsiveContainer>
                     <div className="space-y-2">
-                      {rawData.data.map((r: any, i: number) => (
+                      {(rawData!.data as Array<{ name: string; icon: string; color: string; total: number; transaction_count: number }>).map((r, i: number) => (
                         <div key={i} className="flex items-center justify-between py-2 px-3 rounded-lg hover:bg-zinc-800/30">
                           <div className="flex items-center gap-2">
                             <div className="w-3 h-3 rounded-full" style={{ backgroundColor: r.color || COLORS[i % COLORS.length] }} />
@@ -179,7 +182,7 @@ export default function ReportsPage() {
 
                 {reportType === "income-vs-expenses" && (
                   <ResponsiveContainer width="100%" height={400}>
-                    <BarChart data={rawData.data}>
+                    <BarChart data={rawData.data as IncomeVsExpensesMonth[]}>
                       <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
                       <XAxis dataKey="month" stroke="#71717a" fontSize={12} />
                       <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${(v/1000).toFixed(0)}k`} />
@@ -205,7 +208,7 @@ export default function ReportsPage() {
                         formatter={(value) => formatCurrency(Number(value))}
                       />
                       <Legend />
-                      {rawData.accounts?.map((acc: string, i: number) => (
+                      {(rawData && 'accounts' in rawData ? (rawData as { accounts: string[] }).accounts : []).map((acc: string, i: number) => (
                         <Line key={acc} type="monotone" dataKey={acc} stroke={COLORS[i % COLORS.length]} strokeWidth={2} />
                       ))}
                       <Line type="monotone" dataKey="total" stroke="#fafafa" strokeWidth={2} strokeDasharray="5 5" />
@@ -214,9 +217,10 @@ export default function ReportsPage() {
                 )}
 
                 {reportType === "year-over-year" && (() => {
-                  const years: string[] = rawData.years || []
-                  const yearTotals: { year: string; expenses: number; income: number }[] = rawData.yearTotals || []
-                  const categoryByYear: { year: string; categories: { name: string; color: string; icon: string; total: number }[] }[] = rawData.categoryByYear || []
+                  const yoyData = rawData as YearOverYearData
+                  const years = yoyData.years
+                  const yearTotals = yoyData.yearTotals
+                  const categoryByYear = yoyData.categoryByYear
 
                   return (
                     <div className="space-y-8">
@@ -242,7 +246,7 @@ export default function ReportsPage() {
 
                       {/* Monthly comparison chart */}
                       <ResponsiveContainer width="100%" height={400}>
-                        <BarChart data={rawData.data}>
+                        <BarChart data={(rawData as YearOverYearData).data}>
                           <CartesianGrid strokeDasharray="3 3" stroke="#27272a" />
                           <XAxis dataKey="month" stroke="#71717a" fontSize={12} />
                           <YAxis stroke="#71717a" fontSize={12} tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`} />

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -184,7 +184,7 @@ export default function TransactionsPage() {
       .then(r => r.json())
       .then(d => {
         if (d.splits?.length > 0) {
-          setSplits(d.splits.map((s: any) => ({
+          setSplits(d.splits.map((s: { category_id?: string; amount: number; description?: string }) => ({
             category_id: s.category_id || "",
             amount: String(s.amount),
             description: s.description || "",

--- a/src/lib/__tests__/shared-types.test.ts
+++ b/src/lib/__tests__/shared-types.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+
+const typesSource = fs.readFileSync(
+  path.resolve(__dirname, '../types.ts'),
+  'utf-8'
+)
+
+describe('shared API types', () => {
+  it('exports Account interface', () => {
+    expect(typesSource).toContain('export interface Account')
+  })
+
+  it('exports Category interface', () => {
+    expect(typesSource).toContain('export interface Category')
+  })
+
+  it('exports Transaction interface', () => {
+    expect(typesSource).toContain('export interface Transaction')
+  })
+
+  it('exports TransactionWithDetails extending Transaction', () => {
+    expect(typesSource).toContain('export interface TransactionWithDetails extends Transaction')
+  })
+
+  it('exports Tag interface', () => {
+    expect(typesSource).toContain('export interface Tag')
+  })
+
+  it('exports PaginatedResponse generic', () => {
+    expect(typesSource).toContain('export interface PaginatedResponse<T>')
+  })
+
+  it('exports TransactionsResponse type', () => {
+    expect(typesSource).toContain('export type TransactionsResponse')
+  })
+
+  it('exports report types', () => {
+    expect(typesSource).toContain('export interface SpendingByCategoryItem')
+    expect(typesSource).toContain('export interface MonthlyTrendMonth')
+    expect(typesSource).toContain('export interface IncomeVsExpensesMonth')
+    expect(typesSource).toContain('export interface NetWorthMonth')
+    expect(typesSource).toContain('export interface YearOverYearData')
+    expect(typesSource).toContain('export type ReportResponse')
+  })
+
+  it('exports DashboardData interface', () => {
+    expect(typesSource).toContain('export interface DashboardData')
+  })
+
+  it('exports BudgetItem and BudgetsResponse', () => {
+    expect(typesSource).toContain('export interface BudgetItem')
+    expect(typesSource).toContain('export interface BudgetsResponse')
+  })
+})
+
+describe('reports page eliminates any usage', () => {
+  const reportsSource = fs.readFileSync(
+    path.resolve(__dirname, '../../app/reports/page.tsx'),
+    'utf-8'
+  )
+
+  it('imports ReportResponse from shared types', () => {
+    expect(reportsSource).toContain("import type { ReportResponse")
+  })
+
+  it('uses ReportResponse type for rawData state', () => {
+    expect(reportsSource).toContain('useState<ReportResponse | null>')
+  })
+
+  it('does not use any for rawData state', () => {
+    expect(reportsSource).not.toContain('useState<any>')
+  })
+})
+
+describe('transactions page eliminates any in splits', () => {
+  const txnSource = fs.readFileSync(
+    path.resolve(__dirname, '../../app/transactions/page.tsx'),
+    'utf-8'
+  )
+
+  it('does not use (s: any) for split mapping', () => {
+    expect(txnSource).not.toContain('(s: any)')
+  })
+})

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,160 @@
+// Shared types for API responses and frontend components
+
+// Base database entities
+export interface Account {
+  id: string
+  name: string
+  type: 'checking' | 'savings' | 'credit' | 'investment'
+  institution: string
+  currency: string
+  created_at: string
+}
+
+export interface Category {
+  id: string
+  name: string
+  parent_id: string | null
+  color: string
+  icon: string
+  type: 'income' | 'expense' | 'transfer'
+  budget_amount: number
+  budget_period: string
+  created_at: string
+}
+
+export interface Transaction {
+  id: string
+  account_id: string
+  date: string
+  amount: number
+  raw_description: string
+  display_name: string
+  category_id: string | null
+  is_reconciled: number
+  notes: string
+  created_at: string
+}
+
+export interface Tag {
+  id: string
+  name: string
+  color: string
+  usage_count?: number
+}
+
+// Joined/enriched types returned by API
+export interface TransactionWithDetails extends Transaction {
+  category_name: string | null
+  category_color: string | null
+  category_icon: string | null
+  account_name: string | null
+  tags?: Array<{ id: string; name: string; color: string }>
+}
+
+// API response shapes
+export interface PaginatedResponse<T> {
+  total: number
+  page: number
+  limit: number
+  totalPages: number
+  transactions: T[]
+}
+
+export type TransactionsResponse = PaginatedResponse<TransactionWithDetails>
+
+export interface AccountsResponse {
+  accounts: Account[]
+}
+
+export interface CategoriesResponse {
+  categories: Array<Pick<Category, 'id' | 'name' | 'parent_id' | 'color' | 'icon' | 'type'>>
+}
+
+export interface TagsResponse {
+  tags: Tag[]
+}
+
+// Report types
+export interface SpendingByCategoryItem {
+  id: string
+  name: string
+  color: string
+  icon: string
+  total: number
+  transaction_count: number
+}
+
+export interface MonthlyTrendMonth {
+  month: string
+  categories: Array<{ id: string; name: string; color: string; total: number }>
+}
+
+export interface IncomeVsExpensesMonth {
+  month: string
+  income: number
+  expenses: number
+  net: number
+}
+
+export interface NetWorthMonth {
+  month: string
+  balances: Record<string, number>
+  total: number
+}
+
+export interface YearOverYearData {
+  data: Array<Record<string, number | string>>
+  years: string[]
+  categoryByYear: Array<{
+    year: string
+    categories: Array<{ name: string; color: string; icon: string; total: number }>
+  }>
+  yearTotals: Array<{ year: string; expenses: number; income: number }>
+}
+
+export type ReportResponse =
+  | { data: SpendingByCategoryItem[]; startDate: string; endDate: string }
+  | { data: MonthlyTrendMonth[] }
+  | { data: IncomeVsExpensesMonth[] }
+  | { data: NetWorthMonth[]; accounts: string[] }
+  | YearOverYearData
+
+// Dashboard
+export interface DashboardData {
+  monthlySpending: number
+  lastMonthSpending: number
+  monthlyIncome: number
+  topCategories: Array<{ id: string; name: string; color: string; icon: string; total: number }>
+  recentTransactions: TransactionWithDetails[]
+  accountBalances: Array<Account & { balance: number }>
+  cashFlowByMonth: Array<{ month: string; income: number; expenses: number }>
+  budgetUtilization: Array<{
+    id: string
+    budgeted: number
+    period: string
+    category_id: string
+    category_name: string
+    category_color: string
+    category_icon: string
+    spent: number
+  }>
+}
+
+// Budget
+export interface BudgetItem {
+  id: string
+  category_id: string
+  amount: number
+  period: string
+  start_date: string | null
+  end_date: string | null
+  category_name: string
+  category_color: string
+  category_icon: string
+  category_type: string
+  spent: number
+}
+
+export interface BudgetsResponse {
+  budgets: BudgetItem[]
+}


### PR DESCRIPTION
## Summary
- Adds `src/lib/types.ts` with shared interfaces for all API response shapes (Account, Category, Transaction, TransactionWithDetails, Tag, PaginatedResponse, ReportResponse union, DashboardData, BudgetItem, etc.)
- Replaces all `any` types in `reports/page.tsx` and `transactions/page.tsx` with proper typed alternatives
- Adds 14 tests verifying type exports and correct usage across pages

## Test plan
- [x] All 248 tests pass (`npm test`)
- [x] `npx next build` succeeds with no type errors
- [x] Reports page renders all 5 report types with proper type narrowing
- [x] Transaction split mapping uses typed interface instead of `any`

Closes #26