### PR TITLE
Add payload size limits to bulk and import API endpoints

### DIFF
--- a/src/app/api/import/route.ts
+++ b/src/app/api/import/route.ts
@@ -4,6 +4,8 @@ import { applyAliasesToTransactions } from '@/lib/alias-engine'
 import { applyRulesToTransactions } from '@/lib/rules-engine'
 import { parseDate } from '@/lib/csv-parser'
 
+const MAX_IMPORT_SIZE = 5000
+
 export async function POST(request: Request) {
   try {
     const db = getDb()
@@ -11,6 +13,10 @@ export async function POST(request: Request) {
 
     if (!accountId || !Array.isArray(transactions) || transactions.length === 0) {
       return NextResponse.json({ error: 'accountId and transactions array are required' }, { status: 400 })
+    }
+
+    if (transactions.length > MAX_IMPORT_SIZE) {
+      return NextResponse.json({ error: `Import limited to ${MAX_IMPORT_SIZE} transactions per request` }, { status: 400 })
     }
 
     const account = db.prepare('SELECT id FROM accounts WHERE id = ?').get(accountId)

--- a/src/app/api/transactions/bulk/route.ts
+++ b/src/app/api/transactions/bulk/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
 
+const MAX_BULK_SIZE = 500
+
 export async function PUT(request: Request) {
   try {
     const db = getDb()
@@ -9,6 +11,10 @@ export async function PUT(request: Request) {
 
     if (!Array.isArray(idList) || idList.length === 0) {
       return NextResponse.json({ error: 'ids array is required' }, { status: 400 })
+    }
+
+    if (idList.length > MAX_BULK_SIZE) {
+      return NextResponse.json({ error: `Bulk operations limited to ${MAX_BULK_SIZE} items` }, { status: 400 })
     }
 
     const placeholders = idList.map(() => '?').join(',')
@@ -30,6 +36,10 @@ export async function DELETE(request: Request) {
 
     if (!Array.isArray(ids) || ids.length === 0) {
       return NextResponse.json({ error: 'ids array is required' }, { status: 400 })
+    }
+
+    if (ids.length > MAX_BULK_SIZE) {
+      return NextResponse.json({ error: `Bulk operations limited to ${MAX_BULK_SIZE} items` }, { status: 400 })
     }
 
     const placeholders = ids.map(() => '?').join(',')

--- a/src/lib/__tests__/payload-size-limits.test.ts
+++ b/src/lib/__tests__/payload-size-limits.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+
+/**
+ * Tests that verify payload size limit constants and validation logic
+ * used by bulk and import API endpoints.
+ */
+
+const MAX_BULK_SIZE = 500
+const MAX_IMPORT_SIZE = 5000
+
+describe('bulk endpoint payload size limits', () => {
+  function validateBulkIds(ids: unknown): { error?: string } {
+    if (!Array.isArray(ids) || ids.length === 0) {
+      return { error: 'ids array is required' }
+    }
+    if (ids.length > MAX_BULK_SIZE) {
+      return { error: `Bulk operations limited to ${MAX_BULK_SIZE} items` }
+    }
+    return {}
+  }
+
+  it('accepts an array within the limit', () => {
+    const ids = Array.from({ length: 100 }, (_, i) => `id-${i}`)
+    expect(validateBulkIds(ids)).toEqual({})
+  })
+
+  it('accepts exactly MAX_BULK_SIZE items', () => {
+    const ids = Array.from({ length: MAX_BULK_SIZE }, (_, i) => `id-${i}`)
+    expect(validateBulkIds(ids)).toEqual({})
+  })
+
+  it('rejects more than MAX_BULK_SIZE items', () => {
+    const ids = Array.from({ length: MAX_BULK_SIZE + 1 }, (_, i) => `id-${i}`)
+    const result = validateBulkIds(ids)
+    expect(result.error).toContain('limited to 500')
+  })
+
+  it('rejects empty array', () => {
+    expect(validateBulkIds([])).toEqual({ error: 'ids array is required' })
+  })
+
+  it('rejects non-array input', () => {
+    expect(validateBulkIds('not-array')).toEqual({ error: 'ids array is required' })
+    expect(validateBulkIds(null)).toEqual({ error: 'ids array is required' })
+  })
+})
+
+describe('import endpoint payload size limits', () => {
+  function validateImportTransactions(transactions: unknown): { error?: string } {
+    if (!Array.isArray(transactions) || transactions.length === 0) {
+      return { error: 'accountId and transactions array are required' }
+    }
+    if (transactions.length > MAX_IMPORT_SIZE) {
+      return { error: `Import limited to ${MAX_IMPORT_SIZE} transactions per request` }
+    }
+    return {}
+  }
+
+  it('accepts transactions within the limit', () => {
+    const txns = Array.from({ length: 1000 }, (_, i) => ({ id: i }))
+    expect(validateImportTransactions(txns)).toEqual({})
+  })
+
+  it('accepts exactly MAX_IMPORT_SIZE transactions', () => {
+    const txns = Array.from({ length: MAX_IMPORT_SIZE }, (_, i) => ({ id: i }))
+    expect(validateImportTransactions(txns)).toEqual({})
+  })
+
+  it('rejects more than MAX_IMPORT_SIZE transactions', () => {
+    const txns = Array.from({ length: MAX_IMPORT_SIZE + 1 }, (_, i) => ({ id: i }))
+    const result = validateImportTransactions(txns)
+    expect(result.error).toContain('limited to 5000')
+  })
+
+  it('rejects empty array', () => {
+    expect(validateImportTransactions([])).toEqual({
+      error: 'accountId and transactions array are required',
+    })
+  })
+})
+
+describe('route source contains size limits', () => {
+  const fs = require('fs')
+  const path = require('path')
+
+  it('bulk route defines MAX_BULK_SIZE = 500', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/api/transactions/bulk/route.ts'),
+      'utf-8'
+    )
+    expect(source).toContain('MAX_BULK_SIZE = 500')
+    expect(source).toContain('idList.length > MAX_BULK_SIZE')
+    expect(source).toContain('ids.length > MAX_BULK_SIZE')
+  })
+
+  it('import route defines MAX_IMPORT_SIZE = 5000', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/api/import/route.ts'),
+      'utf-8'
+    )
+    expect(source).toContain('MAX_IMPORT_SIZE = 5000')
+    expect(source).toContain('transactions.length > MAX_IMPORT_SIZE')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds `MAX_BULK_SIZE = 500` limit to `PUT /api/transactions/bulk` and `DELETE /api/transactions/bulk`
- Adds `MAX_IMPORT_SIZE = 5000` limit to `POST /api/import`
- Returns 400 with descriptive error when limits are exceeded
- Adds 11 tests for boundary validation and source verification

## Test plan
- [x] All 259 tests pass (`npm test`)
- [x] `npx next build` succeeds
- [x] Tests verify: within-limit accepted, at-limit accepted, over-limit rejected, empty/invalid input rejected, source contains limit constants

Closes #34