### PR TITLE
Extract reconciliation tolerance and budget thresholds into shared constants

### DIFF
--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -10,6 +10,7 @@ import { Badge } from "@/components/ui/badge"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Skeleton } from "@/components/ui/skeleton"
 import { formatCurrency } from "@/lib/utils"
+import { BUDGET_WARNING_THRESHOLD, BUDGET_OVER_THRESHOLD } from "@/lib/constants"
 import { Plus, Edit2, Trash2, TrendingUp, ChevronRight } from "lucide-react"
 import { toast } from "sonner"
 
@@ -284,7 +285,7 @@ export default function BudgetsPage() {
                       <div className="flex items-center gap-2">
                         <span>{b.category_icon}</span>
                         <span className="font-medium text-zinc-200">{b.category_name}</span>
-                        <Badge variant={pct > 100 ? "destructive" : pct > 75 ? "warning" : "success"} className="text-xs">
+                        <Badge variant={pct > BUDGET_OVER_THRESHOLD ? "destructive" : pct > BUDGET_WARNING_THRESHOLD ? "warning" : "success"} className="text-xs">
                           {pct.toFixed(0)}%
                         </Badge>
                       </div>

--- a/src/app/reconcile/page.tsx
+++ b/src/app/reconcile/page.tsx
@@ -8,6 +8,7 @@ import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
 import { Checkbox } from "@/components/ui/checkbox"
 import { formatCurrency, formatDate } from "@/lib/utils"
+import { RECONCILIATION_TOLERANCE } from "@/lib/constants"
 import { CheckSquare, Lock, AlertCircle } from "lucide-react"
 import { toast } from "sonner"
 
@@ -177,10 +178,10 @@ export default function ReconcilePage() {
             <Card>
               <CardContent className="p-6">
                 <p className="text-sm text-zinc-400">Difference</p>
-                <p className={`text-2xl font-bold mt-1 ${Math.abs(difference) < 0.01 ? 'text-emerald-400' : 'text-red-400'}`}>
+                <p className={`text-2xl font-bold mt-1 ${Math.abs(difference) < RECONCILIATION_TOLERANCE ? 'text-emerald-400' : 'text-red-400'}`}>
                   {formatCurrency(difference)}
                 </p>
-                {Math.abs(difference) < 0.01 && (
+                {Math.abs(difference) < RECONCILIATION_TOLERANCE && (
                   <Badge variant="success" className="mt-1">Balanced!</Badge>
                 )}
               </CardContent>
@@ -193,7 +194,7 @@ export default function ReconcilePage() {
               <div className="flex gap-2">
                 <Button variant="outline" size="sm" onClick={clearAll}>Clear All</Button>
                 <Button variant="outline" size="sm" onClick={() => { setActiveSession(null); setTransactions([]) }}>Cancel</Button>
-                <Button size="sm" onClick={finishReconciliation} disabled={Math.abs(difference) >= 0.01} variant="success">
+                <Button size="sm" onClick={finishReconciliation} disabled={Math.abs(difference) >= RECONCILIATION_TOLERANCE} variant="success">
                   <Lock className="h-4 w-4 mr-1" /> Finish
                 </Button>
               </div>

--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { formatCurrency, formatDate } from "@/lib/utils"
+import { RECURRING_CONFIDENCE_THRESHOLD } from "@/lib/constants"
 import { RefreshCw, CalendarClock, TrendingDown, Plus, Trash2, Check, AlertCircle } from "lucide-react"
 import { toast } from "sonner"
 
@@ -191,7 +192,7 @@ export default function SubscriptionsPage() {
                         <Badge variant="secondary" className={`text-xs ${frequencyColor[p.frequency]}`}>
                           {frequencyLabel[p.frequency]}
                         </Badge>
-                        {p.confidence >= 0.8 && (
+                        {p.confidence >= RECURRING_CONFIDENCE_THRESHOLD && (
                           <Badge variant="success" className="text-xs">High confidence</Badge>
                         )}
                       </div>

--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest'
+import {
+  RECONCILIATION_TOLERANCE,
+  BUDGET_WARNING_THRESHOLD,
+  BUDGET_OVER_THRESHOLD,
+  RECURRING_CONFIDENCE_THRESHOLD,
+} from '../constants'
+
+describe('shared constants', () => {
+  it('exports RECONCILIATION_TOLERANCE as a small positive number', () => {
+    expect(RECONCILIATION_TOLERANCE).toBe(0.01)
+    expect(RECONCILIATION_TOLERANCE).toBeGreaterThan(0)
+  })
+
+  it('exports budget thresholds with warning < over', () => {
+    expect(BUDGET_WARNING_THRESHOLD).toBe(75)
+    expect(BUDGET_OVER_THRESHOLD).toBe(100)
+    expect(BUDGET_WARNING_THRESHOLD).toBeLessThan(BUDGET_OVER_THRESHOLD)
+  })
+
+  it('exports RECURRING_CONFIDENCE_THRESHOLD between 0 and 1', () => {
+    expect(RECURRING_CONFIDENCE_THRESHOLD).toBe(0.8)
+    expect(RECURRING_CONFIDENCE_THRESHOLD).toBeGreaterThan(0)
+    expect(RECURRING_CONFIDENCE_THRESHOLD).toBeLessThanOrEqual(1)
+  })
+})
+
+describe('pages use shared constants (not magic numbers)', () => {
+  const fs = require('fs')
+  const path = require('path')
+
+  it('reconcile page imports RECONCILIATION_TOLERANCE', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/reconcile/page.tsx'), 'utf-8'
+    )
+    expect(source).toContain('RECONCILIATION_TOLERANCE')
+    expect(source).not.toMatch(/Math\.abs\(difference\)\s*<\s*0\.01/)
+    expect(source).not.toMatch(/Math\.abs\(difference\)\s*>=\s*0\.01/)
+  })
+
+  it('budgets page imports BUDGET thresholds', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/budgets/page.tsx'), 'utf-8'
+    )
+    expect(source).toContain('BUDGET_WARNING_THRESHOLD')
+    expect(source).toContain('BUDGET_OVER_THRESHOLD')
+    expect(source).not.toMatch(/pct > 100\b/)
+    expect(source).not.toMatch(/pct > 75\b/)
+  })
+
+  it('subscriptions page imports RECURRING_CONFIDENCE_THRESHOLD', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../../app/subscriptions/page.tsx'), 'utf-8'
+    )
+    expect(source).toContain('RECURRING_CONFIDENCE_THRESHOLD')
+    expect(source).not.toMatch(/confidence >= 0\.8/)
+  })
+})

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -1,0 +1,9 @@
+/** Tolerance for reconciliation balance matching (in currency units) */
+export const RECONCILIATION_TOLERANCE = 0.01
+
+/** Budget utilization percentage thresholds for status badges */
+export const BUDGET_WARNING_THRESHOLD = 75
+export const BUDGET_OVER_THRESHOLD = 100
+
+/** Minimum confidence score to show "High confidence" badge for recurring patterns */
+export const RECURRING_CONFIDENCE_THRESHOLD = 0.8


### PR DESCRIPTION
## Summary
- Creates `src/lib/constants.ts` with named exports: `RECONCILIATION_TOLERANCE`, `BUDGET_WARNING_THRESHOLD`, `BUDGET_OVER_THRESHOLD`, `RECURRING_CONFIDENCE_THRESHOLD`
- Replaces 3 hardcoded `0.01` comparisons in `reconcile/page.tsx` with `RECONCILIATION_TOLERANCE`
- Replaces `pct > 100` / `pct > 75` in `budgets/page.tsx` with named constants
- Replaces `confidence >= 0.8` in `subscriptions/page.tsx` with `RECURRING_CONFIDENCE_THRESHOLD`
- Adds 6 tests verifying constant values and that pages use imports instead of magic numbers

## Test plan
- [x] All 254 tests pass (`npm test`)
- [x] `npx next build` succeeds
- [x] Tests verify no magic numbers remain in source files

Closes #38