### PR TITLE
Add error states to dashboard and transactions pages

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -65,13 +65,18 @@ interface Bill {
 export default function DashboardPage() {
   const [data, setData] = useState<DashboardData | null>(null)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [bills, setBills] = useState<Bill[]>([])
 
   useEffect(() => {
+    setError(null)
     fetch("/api/dashboard")
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`Failed to load dashboard (${r.status})`)
+        return r.json()
+      })
       .then(setData)
-      .catch(console.error)
+      .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
     fetch("/api/bills")
       .then(r => r.json())
@@ -80,6 +85,19 @@ export default function DashboardPage() {
   }, [])
 
   if (loading) return <DashboardSkeleton />
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <AlertCircle className="h-10 w-10 text-red-400 mb-3" />
+        <h2 className="text-lg font-semibold text-zinc-200">Failed to load dashboard</h2>
+        <p className="text-sm text-zinc-500 mt-1 mb-4">{error}</p>
+        <Button variant="outline" size="sm" onClick={() => window.location.reload()}>
+          Try again
+        </Button>
+      </div>
+    )
+  }
 
   if (!data || (data.accountBalances.length === 0 && data.recentTransactions.length === 0)) {
     return <WelcomeScreen />

--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -11,7 +11,7 @@ import { Checkbox } from "@/components/ui/checkbox"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { formatCurrency, formatDate } from "@/lib/utils"
-import { Search, Filter, ChevronLeft, ChevronRight, Save, X, Tags, Trash2, Bookmark, Download, Copy } from "lucide-react"
+import { Search, Filter, ChevronLeft, ChevronRight, Save, X, Tags, Trash2, Bookmark, Download, Copy, AlertCircle } from "lucide-react"
 import { toast } from "sonner"
 
 interface Tag {
@@ -89,6 +89,7 @@ export default function TransactionsPage() {
   const [categories, setCategories] = useState<Category[]>([])
   const [accounts, setAccounts] = useState<Account[]>([])
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [total, setTotal] = useState(0)
   const [page, setPage] = useState(1)
   const [search, setSearch] = useState("")
@@ -137,12 +138,17 @@ export default function TransactionsPage() {
     if (dateTo) params.set("endDate", dateTo)
     if (tagFilter) params.set("tagId", tagFilter)
 
+    setError(null)
     fetch(`/api/transactions?${params}`)
-      .then((r) => r.json())
+      .then((r) => {
+        if (!r.ok) throw new Error(`Failed to load transactions (${r.status})`)
+        return r.json()
+      })
       .then((data) => {
         setTransactions(data.transactions || [])
         setTotal(data.total || 0)
       })
+      .catch((err) => setError(err.message))
       .finally(() => setLoading(false))
   }, [page, debouncedSearch, accountFilter, categoryFilter, dateFrom, dateTo, tagFilter])
 
@@ -495,6 +501,13 @@ export default function TransactionsPage() {
           {loading ? (
             <div className="p-6 space-y-4">
               {[...Array(10)].map((_, i) => <Skeleton key={i} className="h-12 rounded-lg" />)}
+            </div>
+          ) : error ? (
+            <div className="p-12 text-center">
+              <AlertCircle className="h-10 w-10 text-red-400 mx-auto mb-3" />
+              <p className="text-lg text-zinc-200">Failed to load transactions</p>
+              <p className="text-sm text-zinc-500 mt-1 mb-4">{error}</p>
+              <Button variant="outline" size="sm" onClick={fetchTransactions}>Try again</Button>
             </div>
           ) : transactions.length === 0 ? (
             <div className="p-12 text-center text-zinc-500">

--- a/src/lib/__tests__/error-states.test.ts
+++ b/src/lib/__tests__/error-states.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import * as fs from 'fs'
+import * as path from 'path'
+
+describe('dashboard page error handling', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../app/dashboard/page.tsx'),
+    'utf-8'
+  )
+
+  it('declares an error state', () => {
+    expect(source).toContain('useState<string | null>(null)')
+    expect(source).toContain('setError')
+  })
+
+  it('catches fetch errors and sets error state', () => {
+    expect(source).toContain('.catch((err) => setError(err.message))')
+  })
+
+  it('checks response.ok before parsing JSON', () => {
+    expect(source).toContain('if (!r.ok) throw new Error')
+  })
+
+  it('renders an error UI with retry', () => {
+    expect(source).toContain('Failed to load dashboard')
+    expect(source).toContain('Try again')
+  })
+})
+
+describe('transactions page error handling', () => {
+  const source = fs.readFileSync(
+    path.resolve(__dirname, '../../app/transactions/page.tsx'),
+    'utf-8'
+  )
+
+  it('declares an error state', () => {
+    expect(source).toContain('const [error, setError] = useState<string | null>(null)')
+  })
+
+  it('catches fetch errors and sets error state', () => {
+    expect(source).toContain('.catch((err) => setError(err.message))')
+  })
+
+  it('checks response.ok before parsing JSON', () => {
+    expect(source).toContain('if (!r.ok) throw new Error')
+  })
+
+  it('renders an error UI with retry button', () => {
+    expect(source).toContain('Failed to load transactions')
+    expect(source).toContain('fetchTransactions')
+    expect(source).toContain('Try again')
+  })
+})


### PR DESCRIPTION
## Summary
- Dashboard and transactions pages now check `response.ok` before parsing JSON
- On fetch failure, displays an error message with an AlertCircle icon and a "Try again" button
- Dashboard retry reloads the page; transactions retry calls `fetchTransactions()` to re-fetch with current filters
- Adds 8 tests verifying error state declarations, error catching, and error UI rendering

## Test plan
- [x] All 256 tests pass (`npm test`)
- [x] `npx next build` succeeds
- [x] Error UI tested via source verification (error state, catch handler, retry button)

Closes #32