### PR TITLE
Add optimistic UI updates for transactions

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -252,40 +252,78 @@ export default function TransactionsPage() {
 
   const bulkCategorize = async () => {
     if (!bulkCategoryId || selected.size === 0) return
-    await fetch("/api/transactions/bulk", {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: Array.from(selected), category_id: bulkCategoryId }),
-    })
+    const count = selected.size
+    const ids = Array.from(selected)
+    const prev = transactions
+    const cat = categories.find(c => c.id === bulkCategoryId)
+    setTransactions(t => t.map(txn =>
+      selected.has(txn.id)
+        ? { ...txn, category_id: bulkCategoryId, category_name: cat?.name || null, category_icon: cat?.icon || null, category_color: cat?.color || null }
+        : txn
+    ))
     setSelected(new Set())
     setShowBulk(false)
-    fetchTransactions()
-    toast.success(`${selected.size} transactions categorized`)
+    toast.success(`${count} transactions categorized`)
+
+    try {
+      const res = await fetch("/api/transactions/bulk", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids, category_id: bulkCategoryId }),
+      })
+      if (!res.ok) throw new Error()
+    } catch {
+      setTransactions(prev)
+      toast.error("Failed to categorize transactions")
+    }
   }
 
   const deleteTransaction = async (id: string) => {
-    await fetch("/api/transactions", {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ id }),
-    })
+    const prev = transactions
+    const prevTotal = total
+    setTransactions(t => t.filter(txn => txn.id !== id))
+    setTotal(t => t - 1)
     setEditingId(null)
     setEditingTxn(null)
-    fetchTransactions()
     toast.success("Transaction deleted")
+
+    try {
+      const res = await fetch("/api/transactions", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id }),
+      })
+      if (!res.ok) throw new Error()
+    } catch {
+      setTransactions(prev)
+      setTotal(prevTotal)
+      toast.error("Failed to delete transaction")
+    }
   }
 
   const bulkDelete = async () => {
     if (selected.size === 0) return
     const count = selected.size
-    await fetch("/api/transactions/bulk", {
-      method: "DELETE",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ ids: Array.from(selected) }),
-    })
+    const ids = Array.from(selected)
+    const prev = transactions
+    const prevTotal = total
+    setTransactions(t => t.filter(txn => !selected.has(txn.id)))
+    setTotal(t => t - count)
     setSelected(new Set())
-    fetchTransactions()
     toast.success(`${count} transactions deleted`)
+
+    try {
+      const res = await fetch("/api/transactions/bulk", {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids }),
+      })
+      if (!res.ok) throw new Error()
+    } catch {
+      setTransactions(prev)
+      setTotal(prevTotal)
+      toast.error("Failed to delete transactions")
+    }
   }
 
   const saveSplits = async () => {
@@ -382,27 +420,61 @@ export default function TransactionsPage() {
 
   const bulkTag = async (tagId: string) => {
     if (selected.size === 0) return
-    await fetch("/api/transactions/tags", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ transaction_ids: Array.from(selected), tag_id: tagId }),
-    })
+    const count = selected.size
+    const ids = Array.from(selected)
+    const prev = transactions
+    const tag = tags.find(t => t.id === tagId)
+    if (tag) {
+      setTransactions(t => t.map(txn =>
+        selected.has(txn.id) && !txn.tags?.some(t => t.id === tagId)
+          ? { ...txn, tags: [...(txn.tags || []), tag] }
+          : txn
+      ))
+    }
     setSelected(new Set())
-    fetchTransactions()
-    toast.success(`Tagged ${selected.size} transactions`)
+    toast.success(`Tagged ${count} transactions`)
+
+    try {
+      const res = await fetch("/api/transactions/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ transaction_ids: ids, tag_id: tagId }),
+      })
+      if (!res.ok) throw new Error()
+    } catch {
+      setTransactions(prev)
+      toast.error("Failed to tag transactions")
+    }
   }
 
   const toggleTag = async (txnId: string, tagId: string, hasTag: boolean) => {
-    await fetch("/api/transactions/tags", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({
-        transaction_ids: [txnId],
-        tag_id: tagId,
-        action: hasTag ? "remove" : "add",
-      }),
-    })
-    fetchTransactions()
+    const prev = transactions
+    const tag = tags.find(t => t.id === tagId)
+    setTransactions(t => t.map(txn => {
+      if (txn.id !== txnId) return txn
+      return {
+        ...txn,
+        tags: hasTag
+          ? (txn.tags || []).filter(t => t.id !== tagId)
+          : [...(txn.tags || []), ...(tag ? [tag] : [])],
+      }
+    }))
+
+    try {
+      const res = await fetch("/api/transactions/tags", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          transaction_ids: [txnId],
+          tag_id: tagId,
+          action: hasTag ? "remove" : "add",
+        }),
+      })
+      if (!res.ok) throw new Error()
+    } catch {
+      setTransactions(prev)
+      toast.error("Failed to update tag")
+    }
   }
 
   const exportCSV = () => {

--- a/src/lib/__tests__/optimistic-ui.test.ts
+++ b/src/lib/__tests__/optimistic-ui.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const source = readFileSync(
+  join(__dirname, '../../app/transactions/page.tsx'),
+  'utf-8'
+)
+
+describe('Optimistic UI updates in transactions page', () => {
+  describe('deleteTransaction', () => {
+    it('removes transaction from local state before API call', () => {
+      // Should filter out the transaction optimistically
+      expect(source).toContain('setTransactions(t => t.filter(txn => txn.id !== id))')
+    })
+
+    it('decrements total count optimistically', () => {
+      expect(source).toContain('setTotal(t => t - 1)')
+    })
+
+    it('rolls back on API failure', () => {
+      // Should restore previous transactions on error
+      const deleteBlock = source.slice(
+        source.indexOf('const deleteTransaction'),
+        source.indexOf('const bulkDelete')
+      )
+      expect(deleteBlock).toContain('const prev = transactions')
+      expect(deleteBlock).toContain('setTransactions(prev)')
+      expect(deleteBlock).toContain('toast.error("Failed to delete transaction")')
+    })
+  })
+
+  describe('bulkDelete', () => {
+    it('filters out selected transactions optimistically', () => {
+      expect(source).toContain('setTransactions(t => t.filter(txn => !selected.has(txn.id)))')
+    })
+
+    it('rolls back on API failure', () => {
+      const bulkDeleteBlock = source.slice(
+        source.indexOf('const bulkDelete'),
+        source.indexOf('const saveSplits')
+      )
+      expect(bulkDeleteBlock).toContain('const prev = transactions')
+      expect(bulkDeleteBlock).toContain('setTransactions(prev)')
+      expect(bulkDeleteBlock).toContain('toast.error("Failed to delete transactions")')
+    })
+  })
+
+  describe('bulkCategorize', () => {
+    it('updates category in local state optimistically', () => {
+      expect(source).toContain('category_id: bulkCategoryId, category_name: cat?.name')
+    })
+
+    it('rolls back on API failure', () => {
+      const block = source.slice(
+        source.indexOf('const bulkCategorize'),
+        source.indexOf('const deleteTransaction')
+      )
+      expect(block).toContain('const prev = transactions')
+      expect(block).toContain('setTransactions(prev)')
+      expect(block).toContain('toast.error("Failed to categorize transactions")')
+    })
+  })
+
+  describe('toggleTag', () => {
+    it('updates tags in local state optimistically', () => {
+      const block = source.slice(
+        source.indexOf('const toggleTag'),
+        source.indexOf('const exportCSV')
+      )
+      expect(block).toContain('setTransactions(t => t.map(txn =>')
+    })
+
+    it('rolls back on API failure', () => {
+      const block = source.slice(
+        source.indexOf('const toggleTag'),
+        source.indexOf('const exportCSV')
+      )
+      expect(block).toContain('const prev = transactions')
+      expect(block).toContain('setTransactions(prev)')
+      expect(block).toContain('toast.error("Failed to update tag")')
+    })
+  })
+
+  describe('bulkTag', () => {
+    it('adds tag to selected transactions optimistically', () => {
+      const block = source.slice(
+        source.indexOf('const bulkTag'),
+        source.indexOf('const toggleTag')
+      )
+      expect(block).toContain('setTransactions(t => t.map(txn =>')
+    })
+
+    it('rolls back on API failure', () => {
+      const block = source.slice(
+        source.indexOf('const bulkTag'),
+        source.indexOf('const toggleTag')
+      )
+      expect(block).toContain('const prev = transactions')
+      expect(block).toContain('setTransactions(prev)')
+      expect(block).toContain('toast.error("Failed to tag transactions")')
+    })
+  })
+
+  it('does not call fetchTransactions after optimistic operations', () => {
+    // After optimistic update, these functions should NOT refetch
+    const deleteBlock = source.slice(
+      source.indexOf('const deleteTransaction'),
+      source.indexOf('const bulkDelete')
+    )
+    // fetchTransactions should not appear in the delete function body
+    // (the 'prev = transactions' captures state, so no refetch needed)
+    const fetchCallsInDelete = (deleteBlock.match(/fetchTransactions\(\)/g) || []).length
+    expect(fetchCallsInDelete).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary
- Applies immediate local state updates for **delete**, **bulk delete**, **bulk categorize**, **toggle tag**, and **bulk tag** operations — actions now feel instant
- On API failure, rolls back to previous state and shows an error toast
- Removes unnecessary `fetchTransactions()` refetch calls after each operation

## Test plan
- [x] All 327 tests pass (`npm test`)
- [x] Build succeeds (`npx next build`)
- [ ] Delete a transaction — row disappears immediately
- [ ] Bulk delete — selected rows disappear immediately
- [ ] Bulk categorize — category badges update immediately
- [ ] Toggle/bulk tag — tag badges update immediately
- [ ] Simulate network failure — verify rollback and error toast

Closes #37