### PR TITLE
Extract shared transaction filter builder

### DIFF
--- a/src/app/api/transactions/export/route.ts
+++ b/src/app/api/transactions/export/route.ts
@@ -1,59 +1,16 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
 import { toCSV } from '@/lib/csv-export'
+import { buildTransactionFilters } from '@/lib/transaction-filters'
 
 export async function GET(request: NextRequest) {
   try {
     const db = getDb()
     const { searchParams } = new URL(request.url)
 
-    const search = searchParams.get('search')
-    const accountId = searchParams.get('accountId')
-    const categoryId = searchParams.get('categoryId')
     const startDate = searchParams.get('startDate')
     const endDate = searchParams.get('endDate')
-    const isReconciled = searchParams.get('isReconciled')
-    const minAmount = searchParams.get('minAmount')
-    const maxAmount = searchParams.get('maxAmount')
-
-    const conditions: string[] = []
-    const params: any[] = []
-
-    if (search) {
-      conditions.push('(t.raw_description LIKE ? OR t.display_name LIKE ? OR t.notes LIKE ?)')
-      const like = `%${search}%`
-      params.push(like, like, like)
-    }
-    if (accountId) {
-      conditions.push('t.account_id = ?')
-      params.push(accountId)
-    }
-    if (categoryId) {
-      conditions.push('t.category_id = ?')
-      params.push(categoryId)
-    }
-    if (startDate) {
-      conditions.push('t.date >= ?')
-      params.push(startDate)
-    }
-    if (endDate) {
-      conditions.push('t.date <= ?')
-      params.push(endDate)
-    }
-    if (isReconciled !== null && isReconciled !== undefined && isReconciled !== '') {
-      conditions.push('t.is_reconciled = ?')
-      params.push(isReconciled === 'true' ? 1 : 0)
-    }
-    if (minAmount) {
-      conditions.push('t.amount >= ?')
-      params.push(parseFloat(minAmount))
-    }
-    if (maxAmount) {
-      conditions.push('t.amount <= ?')
-      params.push(parseFloat(maxAmount))
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+    const { whereClause, params } = buildTransactionFilters(searchParams)
 
     const transactions = db.prepare(
       `SELECT t.date, t.raw_description, t.display_name, t.amount, t.notes,

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,20 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
 import { createTransactionSchema, updateTransactionSchema, deleteTransactionSchema, validateBody } from '@/lib/validation'
+import { buildTransactionFilters } from '@/lib/transaction-filters'
 
 export async function GET(request: NextRequest) {
   try {
     const db = getDb()
     const { searchParams } = new URL(request.url)
 
-    const search = searchParams.get('search')
-    const accountId = searchParams.get('accountId')
-    const categoryId = searchParams.get('categoryId')
-    const startDate = searchParams.get('startDate')
-    const endDate = searchParams.get('endDate')
-    const isReconciled = searchParams.get('isReconciled')
-    const minAmount = searchParams.get('minAmount')
-    const maxAmount = searchParams.get('maxAmount')
     const rawPage = parseInt(searchParams.get('page') || '1')
     const rawLimit = parseInt(searchParams.get('limit') || '50')
 
@@ -26,50 +19,7 @@ export async function GET(request: NextRequest) {
     const limit = Math.min(Math.max(1, rawLimit), 500)
     const offset = (page - 1) * limit
 
-    const conditions: string[] = []
-    const params: any[] = []
-
-    if (search) {
-      conditions.push('(t.raw_description LIKE ? OR t.display_name LIKE ? OR t.notes LIKE ?)')
-      const like = `%${search}%`
-      params.push(like, like, like)
-    }
-    if (accountId) {
-      conditions.push('t.account_id = ?')
-      params.push(accountId)
-    }
-    if (categoryId) {
-      conditions.push('t.category_id = ?')
-      params.push(categoryId)
-    }
-    if (startDate) {
-      conditions.push('t.date >= ?')
-      params.push(startDate)
-    }
-    if (endDate) {
-      conditions.push('t.date <= ?')
-      params.push(endDate)
-    }
-    if (isReconciled !== null && isReconciled !== undefined && isReconciled !== '') {
-      conditions.push('t.is_reconciled = ?')
-      params.push(isReconciled === 'true' ? 1 : 0)
-    }
-    if (minAmount) {
-      conditions.push('t.amount >= ?')
-      params.push(parseFloat(minAmount))
-    }
-    if (maxAmount) {
-      conditions.push('t.amount <= ?')
-      params.push(parseFloat(maxAmount))
-    }
-
-    const tagId = searchParams.get('tagId')
-    if (tagId) {
-      conditions.push('t.id IN (SELECT transaction_id FROM transaction_tags WHERE tag_id = ?)')
-      params.push(tagId)
-    }
-
-    const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+    const { whereClause, params } = buildTransactionFilters(searchParams)
 
     const countResult = db.prepare(
       `SELECT COUNT(*) as total FROM transactions t ${whereClause}`

--- a/src/lib/__tests__/transaction-filters.test.ts
+++ b/src/lib/__tests__/transaction-filters.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest'
+import { buildTransactionFilters } from '../transaction-filters'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+describe('buildTransactionFilters', () => {
+  it('returns empty WHERE clause with no params', () => {
+    const params = new URLSearchParams()
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toBe('')
+    expect(result.params).toEqual([])
+  })
+
+  it('builds search filter with LIKE on three columns', () => {
+    const params = new URLSearchParams({ search: 'coffee' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('t.raw_description LIKE ?')
+    expect(result.whereClause).toContain('t.display_name LIKE ?')
+    expect(result.whereClause).toContain('t.notes LIKE ?')
+    expect(result.params).toEqual(['%coffee%', '%coffee%', '%coffee%'])
+  })
+
+  it('builds accountId filter', () => {
+    const params = new URLSearchParams({ accountId: 'acc-1' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('t.account_id = ?')
+    expect(result.params).toEqual(['acc-1'])
+  })
+
+  it('builds categoryId filter', () => {
+    const params = new URLSearchParams({ categoryId: 'cat-1' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('t.category_id = ?')
+    expect(result.params).toEqual(['cat-1'])
+  })
+
+  it('builds date range filters', () => {
+    const params = new URLSearchParams({ startDate: '2025-01-01', endDate: '2025-12-31' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('t.date >= ?')
+    expect(result.whereClause).toContain('t.date <= ?')
+    expect(result.params).toEqual(['2025-01-01', '2025-12-31'])
+  })
+
+  it('builds isReconciled filter for true', () => {
+    const params = new URLSearchParams({ isReconciled: 'true' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('t.is_reconciled = ?')
+    expect(result.params).toEqual([1])
+  })
+
+  it('builds isReconciled filter for false', () => {
+    const params = new URLSearchParams({ isReconciled: 'false' })
+    const result = buildTransactionFilters(params)
+    expect(result.params).toEqual([0])
+  })
+
+  it('builds amount range filters', () => {
+    const params = new URLSearchParams({ minAmount: '10.50', maxAmount: '100' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('t.amount >= ?')
+    expect(result.whereClause).toContain('t.amount <= ?')
+    expect(result.params).toEqual([10.50, 100])
+  })
+
+  it('builds tagId filter with subquery', () => {
+    const params = new URLSearchParams({ tagId: 'tag-1' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toContain('transaction_tags')
+    expect(result.params).toEqual(['tag-1'])
+  })
+
+  it('combines multiple filters with AND', () => {
+    const params = new URLSearchParams({ search: 'food', accountId: 'acc-1', startDate: '2025-01-01' })
+    const result = buildTransactionFilters(params)
+    expect(result.whereClause).toMatch(/^WHERE .+ AND .+ AND .+$/)
+    expect(result.params.length).toBe(5) // 3 for search + 1 accountId + 1 date
+  })
+
+  it('returns properly typed params (no any[])', () => {
+    const params = new URLSearchParams({ minAmount: '10', search: 'test' })
+    const result = buildTransactionFilters(params)
+    for (const p of result.params) {
+      expect(typeof p === 'string' || typeof p === 'number').toBe(true)
+    }
+  })
+})
+
+describe('Routes use shared filter builder', () => {
+  it('transactions route imports buildTransactionFilters', () => {
+    const source = readFileSync(
+      join(__dirname, '../../app/api/transactions/route.ts'), 'utf-8'
+    )
+    expect(source).toContain("import { buildTransactionFilters } from '@/lib/transaction-filters'")
+    expect(source).toContain('buildTransactionFilters(searchParams)')
+  })
+
+  it('export route imports buildTransactionFilters', () => {
+    const source = readFileSync(
+      join(__dirname, '../../app/api/transactions/export/route.ts'), 'utf-8'
+    )
+    expect(source).toContain("import { buildTransactionFilters } from '@/lib/transaction-filters'")
+    expect(source).toContain('buildTransactionFilters(searchParams)')
+  })
+
+  it('transactions route no longer has inline filter building', () => {
+    const source = readFileSync(
+      join(__dirname, '../../app/api/transactions/route.ts'), 'utf-8'
+    )
+    // Should not have the old inline params: any[] pattern
+    expect(source).not.toContain('params: any[]')
+  })
+
+  it('export route no longer has inline filter building', () => {
+    const source = readFileSync(
+      join(__dirname, '../../app/api/transactions/export/route.ts'), 'utf-8'
+    )
+    expect(source).not.toContain('params: any[]')
+  })
+})

--- a/src/lib/transaction-filters.ts
+++ b/src/lib/transaction-filters.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared transaction filter builder used by both the transactions GET
+ * and export routes to avoid duplicating filter logic.
+ */
+export function buildTransactionFilters(searchParams: URLSearchParams): {
+  whereClause: string
+  params: (string | number)[]
+} {
+  const conditions: string[] = []
+  const params: (string | number)[] = []
+
+  const search = searchParams.get('search')
+  if (search) {
+    conditions.push('(t.raw_description LIKE ? OR t.display_name LIKE ? OR t.notes LIKE ?)')
+    const like = `%${search}%`
+    params.push(like, like, like)
+  }
+
+  const accountId = searchParams.get('accountId')
+  if (accountId) {
+    conditions.push('t.account_id = ?')
+    params.push(accountId)
+  }
+
+  const categoryId = searchParams.get('categoryId')
+  if (categoryId) {
+    conditions.push('t.category_id = ?')
+    params.push(categoryId)
+  }
+
+  const startDate = searchParams.get('startDate')
+  if (startDate) {
+    conditions.push('t.date >= ?')
+    params.push(startDate)
+  }
+
+  const endDate = searchParams.get('endDate')
+  if (endDate) {
+    conditions.push('t.date <= ?')
+    params.push(endDate)
+  }
+
+  const isReconciled = searchParams.get('isReconciled')
+  if (isReconciled !== null && isReconciled !== undefined && isReconciled !== '') {
+    conditions.push('t.is_reconciled = ?')
+    params.push(isReconciled === 'true' ? 1 : 0)
+  }
+
+  const minAmount = searchParams.get('minAmount')
+  if (minAmount) {
+    conditions.push('t.amount >= ?')
+    params.push(parseFloat(minAmount))
+  }
+
+  const maxAmount = searchParams.get('maxAmount')
+  if (maxAmount) {
+    conditions.push('t.amount <= ?')
+    params.push(parseFloat(maxAmount))
+  }
+
+  const tagId = searchParams.get('tagId')
+  if (tagId) {
+    conditions.push('t.id IN (SELECT transaction_id FROM transaction_tags WHERE tag_id = ?)')
+    params.push(tagId)
+  }
+
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+  return { whereClause, params }
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated filter-building logic from transactions GET and export routes into a shared `buildTransactionFilters()` function in `src/lib/transaction-filters.ts`
- Replaces `params: any[]` with properly typed `(string | number)[]`
- Supports all existing filters: search, accountId, categoryId, date range, amount range, isReconciled, tagId

## Test plan
- [x] All 355 tests pass (`npm test`)
- [x] Build succeeds (`npx next build`)
- [x] 15 new unit tests verify filter builder output for each parameter
- [x] Source verification tests confirm both routes use the shared import
- [ ] Manually verify transaction list filtering still works
- [ ] Manually verify CSV export with filters still works

Closes #58