### PR TITLE
Extract alias match threshold into shared constants

### DIFF
--- a/src/lib/__tests__/constants.test.ts
+++ b/src/lib/__tests__/constants.test.ts
@@ -4,6 +4,7 @@ import {
   BUDGET_WARNING_THRESHOLD,
   BUDGET_OVER_THRESHOLD,
   RECURRING_CONFIDENCE_THRESHOLD,
+  ALIAS_MATCH_THRESHOLD,
 } from '../constants'
 
 describe('shared constants', () => {
@@ -22,6 +23,12 @@ describe('shared constants', () => {
     expect(RECURRING_CONFIDENCE_THRESHOLD).toBe(0.8)
     expect(RECURRING_CONFIDENCE_THRESHOLD).toBeGreaterThan(0)
     expect(RECURRING_CONFIDENCE_THRESHOLD).toBeLessThanOrEqual(1)
+  })
+
+  it('exports ALIAS_MATCH_THRESHOLD between 0 and 1', () => {
+    expect(ALIAS_MATCH_THRESHOLD).toBe(0.5)
+    expect(ALIAS_MATCH_THRESHOLD).toBeGreaterThan(0)
+    expect(ALIAS_MATCH_THRESHOLD).toBeLessThanOrEqual(1)
   })
 })
 
@@ -54,5 +61,13 @@ describe('pages use shared constants (not magic numbers)', () => {
     )
     expect(source).toContain('RECURRING_CONFIDENCE_THRESHOLD')
     expect(source).not.toMatch(/confidence >= 0\.8/)
+  })
+
+  it('alias engine imports ALIAS_MATCH_THRESHOLD', () => {
+    const source = fs.readFileSync(
+      path.resolve(__dirname, '../alias-engine.ts'), 'utf-8'
+    )
+    expect(source).toContain('ALIAS_MATCH_THRESHOLD')
+    expect(source).not.toMatch(/const THRESHOLD = 0\.5/)
   })
 })

--- a/src/lib/alias-engine.ts
+++ b/src/lib/alias-engine.ts
@@ -1,4 +1,5 @@
 import { getDb } from './db'
+import { ALIAS_MATCH_THRESHOLD } from './constants'
 
 interface MerchantAlias {
   id: string
@@ -44,11 +45,10 @@ export function matchAlias(rawDescription: string): MerchantAlias | null {
 
   let bestMatch: MerchantAlias | null = null
   let bestScore = 0
-  const THRESHOLD = 0.5
 
   for (const alias of aliases) {
     const score = calculateSimilarity(rawDescription, alias.raw_pattern)
-    if (score > bestScore && score >= THRESHOLD) {
+    if (score > bestScore && score >= ALIAS_MATCH_THRESHOLD) {
       bestScore = score
       bestMatch = alias
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -7,3 +7,6 @@ export const BUDGET_OVER_THRESHOLD = 100
 
 /** Minimum confidence score to show "High confidence" badge for recurring patterns */
 export const RECURRING_CONFIDENCE_THRESHOLD = 0.8
+
+/** Minimum similarity score for alias engine to match a transaction description */
+export const ALIAS_MATCH_THRESHOLD = 0.5


### PR DESCRIPTION
## Summary
- Moves hardcoded `THRESHOLD = 0.5` from `alias-engine.ts` into `ALIAS_MATCH_THRESHOLD` in `src/lib/constants.ts`
- Consistent with existing pattern for `RECONCILIATION_TOLERANCE`, `BUDGET_WARNING_THRESHOLD`, `BUDGET_OVER_THRESHOLD`, and `RECURRING_CONFIDENCE_THRESHOLD`
- Adds tests verifying the constant value and its usage in alias-engine

## Test plan
- [x] All 357 tests pass (`npm test`)
- [x] Build succeeds (`npx next build`)
- [x] 2 new tests: constant value check + source verification

Closes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Extracted matching threshold configuration into a centralized constant location, improving code maintainability and consistency across the alias matching system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->