### PR TITLE
Add Zod validation to reconciliation API routes

### DIFF
--- a/src/app/api/reconciliation/[id]/route.ts
+++ b/src/app/api/reconciliation/[id]/route.ts
@@ -1,5 +1,26 @@
 import { NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
+import { validateBody, completeReconciliationSchema } from '@/lib/validation'
+
+interface ReconciliationSession {
+  id: string
+  account_id: string
+  statement_date: string
+  statement_balance: number
+  status: string
+  created_at: string
+  account_name: string
+}
+
+interface TransactionRow {
+  id: string
+  amount: number
+  date: string
+  raw_description: string
+  display_name: string
+  category_name: string | null
+  category_color: string | null
+}
 
 export async function GET(
   request: Request,
@@ -14,23 +35,22 @@ export async function GET(
        FROM reconciliation_sessions rs
        JOIN accounts a ON rs.account_id = a.id
        WHERE rs.id = ?`
-    ).get(id) as any
+    ).get(id) as ReconciliationSession | undefined
 
     if (!session) {
       return NextResponse.json({ error: 'Session not found' }, { status: 404 })
     }
 
-    // Get transactions for this account up to the statement date
     const transactions = db.prepare(
       `SELECT t.*, c.name as category_name, c.color as category_color
        FROM transactions t
        LEFT JOIN categories c ON t.category_id = c.id
        WHERE t.account_id = ? AND t.date <= ?
        ORDER BY t.date DESC`
-    ).all(session.account_id, session.statement_date)
+    ).all(session.account_id, session.statement_date) as TransactionRow[]
 
-    const calculatedBalance = (transactions as any[]).reduce(
-      (sum: number, t: any) => sum + t.amount, 0
+    const calculatedBalance = transactions.reduce(
+      (sum, t) => sum + t.amount, 0
     )
 
     return NextResponse.json({
@@ -53,19 +73,22 @@ export async function PUT(
     const { id } = await params
     const db = getDb()
 
-    const session = db.prepare('SELECT * FROM reconciliation_sessions WHERE id = ?').get(id) as any
+    const session = db.prepare('SELECT * FROM reconciliation_sessions WHERE id = ?').get(id) as ReconciliationSession | undefined
     if (!session) {
       return NextResponse.json({ error: 'Session not found' }, { status: 404 })
     }
 
-    const { status, clearedIds } = await request.json()
+    const body = await request.json()
+    const parsed = validateBody(completeReconciliationSchema, body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error }, { status: parsed.status })
+    }
+    const { status, clearedIds } = parsed.data
 
-    // Mark session as completed
     db.prepare(
       "UPDATE reconciliation_sessions SET status = ? WHERE id = ?"
-    ).run(status || 'completed', id)
+    ).run(status, id)
 
-    // Mark cleared transactions as reconciled
     if (clearedIds && clearedIds.length > 0) {
       const placeholders = clearedIds.map(() => '?').join(',')
       db.prepare(

--- a/src/app/api/reconciliation/route.ts
+++ b/src/app/api/reconciliation/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
+import { validateBody, createReconciliationSchema } from '@/lib/validation'
 
 export async function GET() {
   try {
@@ -20,11 +21,12 @@ export async function GET() {
 export async function POST(request: Request) {
   try {
     const db = getDb()
-    const { account_id, statement_date, statement_balance } = await request.json()
-
-    if (!account_id || !statement_date || statement_balance === undefined) {
-      return NextResponse.json({ error: 'account_id, statement_date, and statement_balance are required' }, { status: 400 })
+    const body = await request.json()
+    const parsed = validateBody(createReconciliationSchema, body)
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error }, { status: parsed.status })
     }
+    const { account_id, statement_date, statement_balance } = parsed.data
 
     const id = crypto.randomUUID()
     db.prepare(

--- a/src/lib/__tests__/zod-reconciliation.test.ts
+++ b/src/lib/__tests__/zod-reconciliation.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import {
+  createReconciliationSchema,
+  completeReconciliationSchema,
+  validateBody,
+} from '../validation'
+
+describe('createReconciliationSchema', () => {
+  it('accepts valid reconciliation session', () => {
+    const result = createReconciliationSchema.safeParse({
+      account_id: 'acc-123',
+      statement_date: '2026-03-01',
+      statement_balance: 1500.50,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects missing account_id', () => {
+    const result = createReconciliationSchema.safeParse({
+      statement_date: '2026-03-01',
+      statement_balance: 1500,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing statement_date', () => {
+    const result = createReconciliationSchema.safeParse({
+      account_id: 'acc-123',
+      statement_balance: 1500,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects missing statement_balance', () => {
+    const result = createReconciliationSchema.safeParse({
+      account_id: 'acc-123',
+      statement_date: '2026-03-01',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('rejects invalid date format', () => {
+    const result = createReconciliationSchema.safeParse({
+      account_id: 'acc-123',
+      statement_date: '03/01/2026',
+      statement_balance: 1500,
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts negative statement balance', () => {
+    const result = createReconciliationSchema.safeParse({
+      account_id: 'acc-123',
+      statement_date: '2026-03-01',
+      statement_balance: -200.50,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects non-finite balance', () => {
+    const result = createReconciliationSchema.safeParse({
+      account_id: 'acc-123',
+      statement_date: '2026-03-01',
+      statement_balance: Infinity,
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('completeReconciliationSchema', () => {
+  it('accepts status with defaults', () => {
+    const result = completeReconciliationSchema.safeParse({})
+    expect(result.success).toBe(true)
+    if (result.success) {
+      expect(result.data.status).toBe('completed')
+    }
+  })
+
+  it('accepts completed status with clearedIds', () => {
+    const result = completeReconciliationSchema.safeParse({
+      status: 'completed',
+      clearedIds: ['txn-1', 'txn-2', 'txn-3'],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('accepts in_progress status', () => {
+    const result = completeReconciliationSchema.safeParse({
+      status: 'in_progress',
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects invalid status', () => {
+    const result = completeReconciliationSchema.safeParse({
+      status: 'cancelled',
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts empty clearedIds array', () => {
+    const result = completeReconciliationSchema.safeParse({
+      clearedIds: [],
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('rejects clearedIds with empty strings', () => {
+    const result = completeReconciliationSchema.safeParse({
+      clearedIds: ['txn-1', ''],
+    })
+    expect(result.success).toBe(false)
+  })
+})
+
+describe('validateBody with reconciliation schemas', () => {
+  it('returns success for valid create', () => {
+    const result = validateBody(createReconciliationSchema, {
+      account_id: 'acc-1',
+      statement_date: '2026-01-31',
+      statement_balance: 5000,
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('returns error for invalid create', () => {
+    const result = validateBody(createReconciliationSchema, {})
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.status).toBe(400)
+    }
+  })
+})
+
+describe('reconciliation routes use validateBody', () => {
+  const mainRoute = readFileSync(
+    join(__dirname, '../../app/api/reconciliation/route.ts'),
+    'utf-8'
+  )
+  const idRoute = readFileSync(
+    join(__dirname, '../../app/api/reconciliation/[id]/route.ts'),
+    'utf-8'
+  )
+
+  it('main route imports validateBody and schema', () => {
+    expect(mainRoute).toContain('validateBody')
+    expect(mainRoute).toContain('createReconciliationSchema')
+  })
+
+  it('main route does not use manual validation', () => {
+    expect(mainRoute).not.toMatch(/if\s*\(\s*!account_id/)
+    expect(mainRoute).not.toMatch(/statement_balance === undefined/)
+  })
+
+  it('[id] route imports validateBody and schema', () => {
+    expect(idRoute).toContain('validateBody')
+    expect(idRoute).toContain('completeReconciliationSchema')
+  })
+
+  it('[id] route does not use as any casts', () => {
+    expect(idRoute).not.toContain('as any')
+  })
+
+  it('[id] route uses typed interfaces', () => {
+    expect(idRoute).toContain('ReconciliationSession')
+    expect(idRoute).toContain('TransactionRow')
+  })
+})

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -122,6 +122,20 @@ export const deleteBillSchema = z.object({
   id: uuid,
 })
 
+// Reconciliation schemas
+export const createReconciliationSchema = z.object({
+  account_id: uuid,
+  statement_date: dateString,
+  statement_balance: currencyAmount,
+})
+
+export const completeReconciliationSchema = z.object({
+  status: z.enum(['in_progress', 'completed'], {
+    message: 'Status must be in_progress or completed',
+  }).default('completed'),
+  clearedIds: z.array(z.string().min(1)).optional(),
+})
+
 /**
  * Validate request body against a Zod schema.
  * Returns { data } on success or { error, status } on failure.


### PR DESCRIPTION
## Summary
- Replace manual `if (!account_id || ...)` checks with `validateBody()` + `createReconciliationSchema` in POST handler
- Replace unvalidated `clearedIds` with `completeReconciliationSchema` (typed string array, status enum) in PUT handler
- Eliminate all `as any` casts with typed `ReconciliationSession` and `TransactionRow` interfaces
- Add 20 tests covering both schemas and route source verification

## Test plan
- [x] All 20 new tests pass (`npm test`)
- [x] Full suite (382 tests) passes
- [x] `npx next build` succeeds
- [x] Verified date format validation (YYYY-MM-DD only)
- [x] Verified negative balances are accepted (credit accounts)
- [x] Verified clearedIds rejects empty strings

Closes #56