### PR TITLE
Add error handling to subscriptions and import pages

### DIFF
--- a/src/app/import/page.tsx
+++ b/src/app/import/page.tsx
@@ -5,7 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button"
 import { Select } from "@/components/ui/select"
 import { Badge } from "@/components/ui/badge"
-import { Upload, FileText, Check, AlertCircle, ArrowRight, X } from "lucide-react"
+import { Upload, FileText, Check, AlertCircle, ArrowRight, X, RefreshCw } from "lucide-react"
 import { toast } from "sonner"
 
 interface Account {
@@ -45,10 +45,21 @@ export default function ImportPage() {
   const [importProgress, setImportProgress] = useState({ current: 0, total: 0, fileName: "" })
   const [dragActive, setDragActive] = useState(false)
   const [amountMode, setAmountMode] = useState<"single" | "split">("single")
+  const [accountsError, setAccountsError] = useState<string | null>(null)
 
-  useEffect(() => {
-    fetch("/api/accounts").then((r) => r.json()).then((d) => setAccounts(d.accounts || []))
-  }, [])
+  const loadAccounts = async () => {
+    setAccountsError(null)
+    try {
+      const res = await fetch("/api/accounts")
+      if (!res.ok) throw new Error(`Failed to load accounts (${res.status})`)
+      const d = await res.json()
+      setAccounts(d.accounts || [])
+    } catch (err) {
+      setAccountsError(err instanceof Error ? err.message : "Failed to load accounts")
+    }
+  }
+
+  useEffect(() => { loadAccounts() }, [])
 
   const handleFiles = async (newFiles: FileList | File[]) => {
     const csvFiles = Array.from(newFiles).filter(f => f.name.endsWith(".csv") || f.type === "text/csv")
@@ -64,6 +75,10 @@ export default function ImportPage() {
 
     try {
       const res = await fetch("/api/import/parse", { method: "POST", body: formData })
+      if (!res.ok) {
+        toast.error(`Failed to parse CSV (${res.status})`)
+        return
+      }
       const data = await res.json()
       if (data.error) {
         toast.error(data.error)
@@ -106,6 +121,7 @@ export default function ImportPage() {
     formData.append("mapping", JSON.stringify(mapping))
 
     const parseRes = await fetch("/api/import/parse", { method: "POST", body: formData })
+    if (!parseRes.ok) throw new Error(`Failed to parse ${file.name} (${parseRes.status})`)
     const parseData = await parseRes.json()
 
     const { headers: h, allRows } = parseData
@@ -139,6 +155,7 @@ export default function ImportPage() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ accountId, transactions }),
     })
+    if (!res.ok) throw new Error(`Import failed for ${file.name} (${res.status})`)
     const data = await res.json()
     return { name: file.name, imported: data.imported, duplicates: data.duplicates, matched: data.matched }
   }
@@ -198,6 +215,22 @@ export default function ImportPage() {
           )
         })}
       </div>
+
+      {/* Error loading accounts */}
+      {accountsError && (
+        <Card>
+          <CardContent className="p-8">
+            <div className="flex flex-col items-center justify-center py-8 text-center">
+              <AlertCircle className="h-10 w-10 text-red-400 mb-3" />
+              <h2 className="text-lg font-semibold text-zinc-200">Failed to load accounts</h2>
+              <p className="text-sm text-zinc-500 mt-1 mb-4">{accountsError}</p>
+              <Button variant="outline" size="sm" onClick={loadAccounts}>
+                <RefreshCw className="h-4 w-4 mr-1" /> Try again
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Step: Upload */}
       {step === "upload" && (

--- a/src/app/subscriptions/page.tsx
+++ b/src/app/subscriptions/page.tsx
@@ -35,14 +35,18 @@ export default function SubscriptionsPage() {
   const [patterns, setPatterns] = useState<RecurringPattern[]>([])
   const [totalMonthly, setTotalMonthly] = useState(0)
   const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [bills, setBills] = useState<Bill[]>([])
   const [showBillDialog, setShowBillDialog] = useState(false)
   const [billForm, setBillForm] = useState({
     name: "", amount: "", frequency: "monthly", next_due_date: ""
   })
 
-  const fetchBills = () => {
-    fetch("/api/bills").then(r => r.json()).then(d => setBills(d.bills || []))
+  const fetchBills = async () => {
+    const res = await fetch("/api/bills")
+    if (!res.ok) throw new Error(`Failed to load bills (${res.status})`)
+    const d = await res.json()
+    setBills(d.bills || [])
   }
 
   const createBill = async () => {
@@ -85,19 +89,22 @@ export default function SubscriptionsPage() {
 
   const fetch_ = async () => {
     setLoading(true)
+    setError(null)
     try {
       const res = await fetch("/api/transactions/recurring")
+      if (!res.ok) throw new Error(`Failed to load recurring transactions (${res.status})`)
       const data = await res.json()
       setPatterns(data.patterns || [])
       setTotalMonthly(data.totalMonthly || 0)
-    } catch {
-      toast.error("Failed to load recurring transactions")
+      await fetchBills()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load subscriptions")
     } finally {
       setLoading(false)
     }
   }
 
-  useEffect(() => { fetch_(); fetchBills() }, [])
+  useEffect(() => { fetch_() }, [])
 
   const totalAnnual = patterns.reduce((s, p) => s + p.totalAnnual, 0)
 
@@ -127,6 +134,19 @@ export default function SubscriptionsPage() {
           <Skeleton className="h-24" />
         </div>
         <Skeleton className="h-64" />
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 text-center">
+        <AlertCircle className="h-10 w-10 text-red-400 mb-3" />
+        <h2 className="text-lg font-semibold text-zinc-200">Failed to load subscriptions</h2>
+        <p className="text-sm text-zinc-500 mt-1 mb-4">{error}</p>
+        <Button variant="outline" size="sm" onClick={() => fetch_()}>
+          Try again
+        </Button>
       </div>
     )
   }

--- a/src/lib/__tests__/error-handling-pages.test.ts
+++ b/src/lib/__tests__/error-handling-pages.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const subscriptionsSource = readFileSync(
+  join(__dirname, '../../app/subscriptions/page.tsx'),
+  'utf-8'
+)
+
+const importSource = readFileSync(
+  join(__dirname, '../../app/import/page.tsx'),
+  'utf-8'
+)
+
+describe('Subscriptions page error handling', () => {
+  it('has error state', () => {
+    expect(subscriptionsSource).toContain('const [error, setError] = useState<string | null>(null)')
+  })
+
+  it('checks response.ok on recurring transactions fetch', () => {
+    expect(subscriptionsSource).toContain('if (!res.ok) throw new Error')
+  })
+
+  it('checks response.ok on bills fetch', () => {
+    expect(subscriptionsSource).toContain('if (!res.ok) throw new Error(`Failed to load bills')
+  })
+
+  it('sets error state on catch', () => {
+    expect(subscriptionsSource).toContain('setError(')
+  })
+
+  it('clears error on retry', () => {
+    expect(subscriptionsSource).toContain('setError(null)')
+  })
+
+  it('renders error UI with AlertCircle', () => {
+    expect(subscriptionsSource).toContain('if (error)')
+    expect(subscriptionsSource).toContain('AlertCircle')
+    expect(subscriptionsSource).toContain('Failed to load subscriptions')
+  })
+
+  it('has a retry button in error state', () => {
+    expect(subscriptionsSource).toContain('Try again')
+  })
+})
+
+describe('Import page error handling', () => {
+  it('has accountsError state', () => {
+    expect(importSource).toContain('const [accountsError, setAccountsError] = useState<string | null>(null)')
+  })
+
+  it('checks response.ok on accounts fetch', () => {
+    expect(importSource).toContain('if (!res.ok) throw new Error(`Failed to load accounts')
+  })
+
+  it('checks response.ok on parse fetch', () => {
+    expect(importSource).toContain('Failed to parse CSV')
+    expect(importSource).toContain('if (!res.ok)')
+  })
+
+  it('checks response.ok on import fetch', () => {
+    expect(importSource).toMatch(/if \(!res\.ok\).*Import failed/)
+  })
+
+  it('checks response.ok on parseAndImportFile parse step', () => {
+    expect(importSource).toMatch(/if \(!parseRes\.ok\)/)
+  })
+
+  it('renders error UI for accounts loading failure', () => {
+    expect(importSource).toContain('accountsError')
+    expect(importSource).toContain('Failed to load accounts')
+    expect(importSource).toContain('Try again')
+  })
+
+  it('has a loadAccounts retry function', () => {
+    expect(importSource).toContain('const loadAccounts = async')
+    expect(importSource).toContain('onClick={loadAccounts}')
+  })
+})


### PR DESCRIPTION
## Summary
- Add `error` state and `response.ok` checks to subscriptions page for both recurring transactions and bills fetches
- Add `accountsError` state and `response.ok` checks to import page for accounts, CSV parse, and import API calls
- Display error UI with AlertCircle icon, message, and retry button (matching dashboard/transactions pattern)
- Add 14 tests verifying error state, response.ok checks, error UI, and retry functionality

## Test plan
- [x] All 14 new tests pass (`npm test`)
- [x] Full suite (396 tests) passes
- [x] `npx next build` succeeds
- [x] Verified error UI matches existing dashboard pattern
- [x] Verified retry buttons call the correct reload functions

Closes #53