### PR TITLE
Add confirmation dialog before deleting categories

### DIFF
--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -6,7 +6,8 @@ export async function GET() {
   try {
     const db = getDb()
     const categories = db.prepare(
-      `SELECT c.*, p.name as parent_name
+      `SELECT c.*, p.name as parent_name,
+              (SELECT COUNT(*) FROM transactions t WHERE t.category_id = c.id) as transaction_count
        FROM categories c
        LEFT JOIN categories p ON c.parent_id = p.id
        ORDER BY c.type, c.name`
@@ -107,7 +108,30 @@ export async function DELETE(request: Request) {
       return NextResponse.json({ error: validation.error }, { status: 400 })
     }
 
-    const result = db.prepare('DELETE FROM categories WHERE id = ?').run(validation.data.id)
+    const { id } = validation.data
+    const existing = db.prepare('SELECT id FROM categories WHERE id = ?').get(id)
+    if (!existing) {
+      return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+    }
+
+    // If confirm=false, return the transaction count without deleting
+    if (body.confirm === false) {
+      const count = db.prepare(
+        'SELECT COUNT(*) as count FROM transactions WHERE category_id = ?'
+      ).get(id) as { count: number }
+      return NextResponse.json({ transactionCount: count.count })
+    }
+
+    // Optionally reassign transactions to another category before deleting
+    if (body.reassignTo) {
+      const target = db.prepare('SELECT id FROM categories WHERE id = ?').get(body.reassignTo)
+      if (!target) {
+        return NextResponse.json({ error: 'Reassign target category not found' }, { status: 404 })
+      }
+      db.prepare('UPDATE transactions SET category_id = ? WHERE category_id = ?').run(body.reassignTo, id)
+    }
+
+    const result = db.prepare('DELETE FROM categories WHERE id = ?').run(id)
     if (result.changes === 0) {
       return NextResponse.json({ error: 'Category not found' }, { status: 404 })
     }

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,7 +9,7 @@ import { Badge } from "@/components/ui/badge"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Checkbox } from "@/components/ui/checkbox"
 import { formatDate } from "@/lib/utils"
-import { Plus, Trash2, Edit2, Building2, Tag, RefreshCw, Tags, Zap, Play, Pause, Sparkles, Check, X, Loader2, Download, Upload, HardDrive, ShieldCheck } from "lucide-react"
+import { Plus, Trash2, Edit2, Building2, Tag, RefreshCw, Tags, Zap, Play, Pause, Sparkles, Check, X, Loader2, Download, Upload, HardDrive, ShieldCheck, AlertTriangle } from "lucide-react"
 import { toast } from "sonner"
 import type { AccountWithBalance } from "@/lib/types"
 
@@ -19,7 +19,7 @@ interface Alias {
 }
 
 interface Category {
-  id: string; name: string; icon: string;
+  id: string; name: string; icon: string; type: string; color: string; transaction_count: number;
 }
 
 interface TagItem {
@@ -80,6 +80,8 @@ export default function SettingsPage() {
   const [checkingHealth, setCheckingHealth] = useState(false)
   const [restoring, setRestoring] = useState(false)
   const [accountErrors, setAccountErrors] = useState<{ name?: string }>({})
+  const [deletingCategory, setDeletingCategory] = useState<Category | null>(null)
+  const [categoryReassignTo, setCategoryReassignTo] = useState("")
 
   const fetchData = () => {
     fetch("/api/accounts").then(r => r.json()).then(d => setAccounts(d.accounts || []))
@@ -439,6 +441,30 @@ export default function SettingsPage() {
     toast.success("Tag deleted")
   }
 
+  const startDeleteCategory = (cat: Category) => {
+    setDeletingCategory(cat)
+    setCategoryReassignTo("")
+  }
+
+  const confirmDeleteCategory = async () => {
+    if (!deletingCategory) return
+    const body: Record<string, unknown> = { id: deletingCategory.id }
+    if (categoryReassignTo) body.reassignTo = categoryReassignTo
+    const res = await fetch("/api/categories", {
+      method: "DELETE",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    const data = await res.json()
+    setDeletingCategory(null)
+    if (!res.ok) {
+      toast.error(data.error || "Failed to delete category")
+      return
+    }
+    fetchData()
+    toast.success("Category deleted")
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -588,6 +614,47 @@ export default function SettingsPage() {
                     aria-label={`Delete ${tag.name}`}
                   >
                     <Trash2 className="h-2.5 w-2.5" aria-hidden="true" />
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Categories */}
+      <Card>
+        <CardHeader>
+          <div>
+            <CardTitle className="flex items-center gap-2"><Tag className="h-5 w-5" /> Categories</CardTitle>
+            <CardDescription>Manage transaction categories</CardDescription>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {categories.length === 0 ? (
+            <div className="py-8 text-center text-zinc-500">
+              <p>No categories yet.</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {categories.map(cat => (
+                <div key={cat.id} className="flex items-center justify-between py-3 px-4 rounded-lg bg-zinc-800/30 hover:bg-zinc-800/50">
+                  <div className="flex items-center gap-2">
+                    <span>{cat.icon}</span>
+                    <span className="font-medium text-zinc-200">{cat.name}</span>
+                    <Badge variant="secondary" className="text-xs capitalize">{cat.type}</Badge>
+                    {cat.transaction_count > 0 && (
+                      <span className="text-xs text-zinc-500">{cat.transaction_count} txn{cat.transaction_count !== 1 ? 's' : ''}</span>
+                    )}
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-7 w-7 text-red-400"
+                    onClick={() => startDeleteCategory(cat)}
+                    aria-label={`Delete ${cat.name}`}
+                  >
+                    <Trash2 className="h-3 w-3" aria-hidden="true" />
                   </Button>
                 </div>
               ))}
@@ -784,6 +851,46 @@ export default function SettingsPage() {
           <div className="flex gap-2 justify-end mt-4">
             <Button variant="outline" onClick={() => setDeletingAccount(null)}>Cancel</Button>
             <Button variant="destructive" onClick={confirmDeleteAccount}>Delete Account</Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* Delete Category Confirm */}
+      <Dialog open={!!deletingCategory} onOpenChange={(open) => { if (!open) { setDeletingCategory(null); setCategoryReassignTo("") } }}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Category</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <p className="text-sm text-zinc-300">
+              Are you sure you want to delete <span className="font-semibold text-zinc-100">{deletingCategory?.icon} {deletingCategory?.name}</span>?
+            </p>
+            {deletingCategory && deletingCategory.transaction_count > 0 && (
+              <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-400/10 border border-amber-400/20">
+                <AlertTriangle className="h-4 w-4 text-amber-400 mt-0.5 shrink-0" />
+                <div className="text-sm">
+                  <p className="text-amber-300 font-medium">
+                    {deletingCategory.transaction_count} transaction{deletingCategory.transaction_count !== 1 ? 's' : ''} will become uncategorized
+                  </p>
+                  <p className="text-zinc-400 text-xs mt-1">You can reassign them to another category before deleting.</p>
+                </div>
+              </div>
+            )}
+            {deletingCategory && deletingCategory.transaction_count > 0 && categories.filter(c => c.id !== deletingCategory.id).length > 0 && (
+              <div>
+                <label className="text-sm text-zinc-400 mb-1 block">Reassign transactions to</label>
+                <Select value={categoryReassignTo} onChange={e => setCategoryReassignTo(e.target.value)}>
+                  <option value="">Leave uncategorized</option>
+                  {categories.filter(c => c.id !== deletingCategory.id).map(c => (
+                    <option key={c.id} value={c.id}>{c.icon} {c.name}</option>
+                  ))}
+                </Select>
+              </div>
+            )}
+            <div className="flex gap-2 justify-end">
+              <Button variant="outline" onClick={() => { setDeletingCategory(null); setCategoryReassignTo("") }}>Cancel</Button>
+              <Button variant="destructive" onClick={confirmDeleteCategory}>Delete Category</Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/src/lib/__tests__/category-delete-confirmation.test.ts
+++ b/src/lib/__tests__/category-delete-confirmation.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const settingsSource = readFileSync(
+  join(__dirname, '../../app/settings/page.tsx'),
+  'utf-8'
+)
+
+const categoriesRouteSource = readFileSync(
+  join(__dirname, '../../app/api/categories/route.ts'),
+  'utf-8'
+)
+
+describe('Categories API transaction count', () => {
+  it('includes transaction_count in GET response', () => {
+    expect(categoriesRouteSource).toContain('transaction_count')
+    expect(categoriesRouteSource).toContain('SELECT COUNT(*) FROM transactions t WHERE t.category_id = c.id')
+  })
+
+  it('supports confirm=false to get transaction count without deleting', () => {
+    expect(categoriesRouteSource).toContain('confirm === false')
+    expect(categoriesRouteSource).toContain('transactionCount')
+  })
+
+  it('supports reassignTo parameter to move transactions before delete', () => {
+    expect(categoriesRouteSource).toContain('reassignTo')
+    expect(categoriesRouteSource).toContain('UPDATE transactions SET category_id = ?')
+  })
+
+  it('validates reassign target category exists', () => {
+    expect(categoriesRouteSource).toContain('Reassign target category not found')
+  })
+})
+
+describe('Settings page category delete confirmation', () => {
+  it('has Category interface with transaction_count', () => {
+    expect(settingsSource).toContain('transaction_count: number')
+  })
+
+  it('has deletingCategory state', () => {
+    expect(settingsSource).toContain('deletingCategory')
+    expect(settingsSource).toContain('setDeletingCategory')
+  })
+
+  it('has categoryReassignTo state', () => {
+    expect(settingsSource).toContain('categoryReassignTo')
+    expect(settingsSource).toContain('setCategoryReassignTo')
+  })
+
+  it('has a Categories section in settings', () => {
+    expect(settingsSource).toContain('Categories')
+    expect(settingsSource).toContain('Manage transaction categories')
+  })
+
+  it('shows transaction count per category in the list', () => {
+    expect(settingsSource).toContain('cat.transaction_count')
+  })
+
+  it('has a delete button per category', () => {
+    expect(settingsSource).toContain('startDeleteCategory')
+  })
+
+  it('has a Delete Category confirmation dialog', () => {
+    expect(settingsSource).toContain('Delete Category')
+    expect(settingsSource).toContain('confirmDeleteCategory')
+  })
+
+  it('warns about transactions becoming uncategorized', () => {
+    expect(settingsSource).toContain('will become uncategorized')
+  })
+
+  it('offers reassignment to another category', () => {
+    expect(settingsSource).toContain('Reassign transactions to')
+    expect(settingsSource).toContain('Leave uncategorized')
+  })
+
+  it('uses AlertTriangle icon for warning', () => {
+    expect(settingsSource).toContain('AlertTriangle')
+  })
+
+  it('has confirmDeleteCategory function that sends reassignTo', () => {
+    expect(settingsSource).toContain('reassignTo')
+    expect(settingsSource).toContain('confirmDeleteCategory')
+  })
+})


### PR DESCRIPTION
## Summary
- Adds a Categories management section to the settings page showing each category with its transaction count
- When deleting a category that has transactions, shows an amber warning with the count
- Offers a "Reassign transactions to" dropdown so users can move transactions to another category before deletion
- API enhanced: `confirm=false` returns transaction count preview; `reassignTo` bulk-reassigns before delete
- Categories GET now includes `transaction_count` per category

## Test plan
- [x] 15 new tests in `category-delete-confirmation.test.ts`
- [x] All 458 tests pass
- [x] `npx next build` succeeds

Closes #51