### PR TITLE
Add error handling for reference data fetches on transactions page

### DIFF
--- a/src/app/transactions/page.tsx
+++ b/src/app/transactions/page.tsx
@@ -159,9 +159,18 @@ export default function TransactionsPage() {
   }, [fetchTransactions])
 
   useEffect(() => {
-    fetch("/api/categories").then((r) => r.json()).then((d) => setCategories(d.categories || []))
-    fetch("/api/accounts").then((r) => r.json()).then((d) => setAccounts(d.accounts || []))
-    fetch("/api/tags").then((r) => r.json()).then((d) => setTags(d.tags || []))
+    fetch("/api/categories")
+      .then((r) => { if (!r.ok) throw new Error("Failed to load categories"); return r.json() })
+      .then((d) => setCategories(d.categories || []))
+      .catch(() => toast.error("Failed to load categories"))
+    fetch("/api/accounts")
+      .then((r) => { if (!r.ok) throw new Error("Failed to load accounts"); return r.json() })
+      .then((d) => setAccounts(d.accounts || []))
+      .catch(() => toast.error("Failed to load accounts"))
+    fetch("/api/tags")
+      .then((r) => { if (!r.ok) throw new Error("Failed to load tags"); return r.json() })
+      .then((d) => setTags(d.tags || []))
+      .catch(() => toast.error("Failed to load tags"))
   }, [])
 
   const totalPages = Math.ceil(total / limit)

--- a/src/lib/__tests__/transactions-error-handling.test.ts
+++ b/src/lib/__tests__/transactions-error-handling.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const source = readFileSync(
+  join(__dirname, '../../app/transactions/page.tsx'),
+  'utf-8'
+)
+
+describe('Transactions page reference data error handling', () => {
+  it('checks response.ok for categories fetch', () => {
+    expect(source).toContain('Failed to load categories')
+  })
+
+  it('checks response.ok for accounts fetch', () => {
+    expect(source).toContain('Failed to load accounts')
+  })
+
+  it('checks response.ok for tags fetch', () => {
+    expect(source).toContain('Failed to load tags')
+  })
+
+  it('has .catch() handlers for all three fetches', () => {
+    // Count occurrences of .catch in the reference data useEffect
+    const refDataBlock = source.slice(
+      source.indexOf('fetch("/api/categories")'),
+      source.indexOf('}, [])', source.indexOf('fetch("/api/categories")'))
+    )
+    const catchCount = (refDataBlock.match(/\.catch\(/g) || []).length
+    expect(catchCount).toBe(3)
+  })
+
+  it('shows toast errors on fetch failure', () => {
+    expect(source).toContain('toast.error("Failed to load categories")')
+    expect(source).toContain('toast.error("Failed to load accounts")')
+    expect(source).toContain('toast.error("Failed to load tags")')
+  })
+
+  it('throws on non-ok response before parsing JSON', () => {
+    expect(source).toContain('if (!r.ok) throw new Error')
+  })
+})


### PR DESCRIPTION
## Summary
- Categories, accounts, and tags fetches on the transactions page now check `response.ok` before parsing JSON
- Non-OK responses throw an error that is caught by `.catch()` handlers
- Each failed fetch shows a specific toast error message (e.g. "Failed to load categories")

Closes #74

## Test plan
- [x] 6 new source-level tests verify error handling patterns exist
- [x] All 546 tests pass
- [x] Build passes