### PR TITLE
Add error handling for dashboard bills fetch

### DIFF
--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -69,6 +69,7 @@ export default function DashboardPage() {
   const [error, setError] = useState<string | null>(null)
   const [bills, setBills] = useState<Bill[]>([])
   const [billsLoading, setBillsLoading] = useState(true)
+  const [billsError, setBillsError] = useState<string | null>(null)
 
   useEffect(() => {
     setError(null)
@@ -81,9 +82,12 @@ export default function DashboardPage() {
       .catch((err) => setError(err.message))
       .finally(() => setDashboardLoading(false))
     fetch("/api/bills")
-      .then(r => r.json())
+      .then(r => {
+        if (!r.ok) throw new Error("Failed to load bills")
+        return r.json()
+      })
       .then(d => setBills(d.bills || []))
-      .catch(() => {})
+      .catch((err) => setBillsError(err.message))
       .finally(() => setBillsLoading(false))
   }, [])
 
@@ -456,6 +460,20 @@ export default function DashboardPage() {
               {[...Array(3)].map((_, i) => (
                 <Skeleton key={i} className="h-10 w-full rounded-lg" />
               ))}
+            </div>
+          </CardContent>
+        </Card>
+      ) : billsError ? (
+        <Card>
+          <CardHeader className="flex flex-row items-center justify-between">
+            <CardTitle className="text-base flex items-center gap-2">
+              <CalendarClock className="h-4 w-4" /> Bills This Month
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex items-center gap-2 text-sm text-red-400">
+              <AlertCircle className="h-4 w-4" />
+              <span>{billsError}</span>
             </div>
           </CardContent>
         </Card>

--- a/src/lib/__tests__/dashboard-bills-error.test.ts
+++ b/src/lib/__tests__/dashboard-bills-error.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const source = readFileSync(
+  join(__dirname, '../../app/dashboard/page.tsx'),
+  'utf-8'
+)
+
+describe('Dashboard bills fetch error handling', () => {
+  it('checks response.ok before parsing bills JSON', () => {
+    expect(source).toContain('if (!r.ok) throw new Error("Failed to load bills")')
+  })
+
+  it('has a billsError state', () => {
+    expect(source).toContain('billsError')
+    expect(source).toContain('setBillsError')
+  })
+
+  it('sets billsError in the catch handler', () => {
+    expect(source).toContain('setBillsError(err.message)')
+  })
+
+  it('displays billsError with an AlertCircle icon', () => {
+    expect(source).toContain('{billsError}')
+  })
+
+  it('shows bills error state before the bills list', () => {
+    const errorIdx = source.indexOf('billsError ?')
+    const listIdx = source.indexOf('bills.length > 0')
+    expect(errorIdx).toBeGreaterThan(0)
+    expect(errorIdx).toBeLessThan(listIdx)
+  })
+})


### PR DESCRIPTION
## Summary
- Bills fetch now checks `response.ok` before parsing JSON
- Added `billsError` state to track and display fetch failures
- Shows inline error message with AlertCircle icon in the bills card on failure

Closes #75

## Test plan
- [x] 5 new source-level tests verify error handling patterns
- [x] All 545 tests pass
- [x] Build passes