### PR TITLE
Replace error: any with error: unknown in catch blocks

### DIFF
--- a/src/app/api/ai/anomalies/route.ts
+++ b/src/app/api/ai/anomalies/route.ts
@@ -126,9 +126,9 @@ Respond ONLY with valid JSON, no other text. Use this exact format:
     const elapsed = ((Date.now() - routeStart) / 1000).toFixed(1)
     console.log(`[anomalies] Done in ${elapsed}s`)
     return NextResponse.json(result)
-  } catch (error: any) {
+  } catch (error: unknown) {
     const elapsed = ((Date.now() - routeStart) / 1000).toFixed(1)
-    if (error.message === 'CLAUDE_NOT_FOUND') {
+    if (error instanceof Error && error.message === 'CLAUDE_NOT_FOUND') {
       console.error(`[anomalies] Claude CLI not found (${elapsed}s)`)
       return NextResponse.json({ error: 'CLAUDE_NOT_FOUND' }, { status: 503 })
     }

--- a/src/app/api/ai/budget-suggestions/route.ts
+++ b/src/app/api/ai/budget-suggestions/route.ts
@@ -92,9 +92,9 @@ Respond ONLY with valid JSON, no other text. Use this exact format:
     const elapsed = ((Date.now() - routeStart) / 1000).toFixed(1)
     console.log(`[budget-suggestions] Done in ${elapsed}s`)
     return NextResponse.json(result)
-  } catch (error: any) {
+  } catch (error: unknown) {
     const elapsed = ((Date.now() - routeStart) / 1000).toFixed(1)
-    if (error.message === 'CLAUDE_NOT_FOUND') {
+    if (error instanceof Error && error.message === 'CLAUDE_NOT_FOUND') {
       console.error(`[budget-suggestions] Claude CLI not found (${elapsed}s)`)
       return NextResponse.json({ error: 'CLAUDE_NOT_FOUND' }, { status: 503 })
     }

--- a/src/app/api/ai/suggest-aliases/route.ts
+++ b/src/app/api/ai/suggest-aliases/route.ts
@@ -81,9 +81,9 @@ Be concise with patterns — use the shortest unique substring. For example, "ST
     }
 
     return NextResponse.json({ suggestions })
-  } catch (error: any) {
+  } catch (error: unknown) {
     console.error('Error suggesting aliases:', error)
-    if (error.message === 'CLAUDE_NOT_FOUND') {
+    if (error instanceof Error && error.message === 'CLAUDE_NOT_FOUND') {
       return NextResponse.json({ error: 'Claude CLI not installed' }, { status: 503 })
     }
     return NextResponse.json({ error: 'Failed to generate suggestions' }, { status: 500 })

--- a/src/app/insights/page.tsx
+++ b/src/app/insights/page.tsx
@@ -37,8 +37,8 @@ function useAI<T>(endpoint: string) {
         return
       }
       setResult({ data: data.data || data, error: null, loading: false, cached_at: data.cached_at || null })
-    } catch (e: any) {
-      setResult({ data: null, error: e.message, loading: false, cached_at: null })
+    } catch (e: unknown) {
+      setResult({ data: null, error: e instanceof Error ? e.message : 'An unexpected error occurred', loading: false, cached_at: null })
     }
   }
 
@@ -76,8 +76,8 @@ export default function InsightsPage() {
       } else {
         setQueryResult(data.answer)
       }
-    } catch (e: any) {
-      setQueryError(e.message)
+    } catch (e: unknown) {
+      setQueryError(e instanceof Error ? e.message : 'An unexpected error occurred')
     } finally {
       setQueryLoading(false)
     }

--- a/src/lib/__tests__/error-any-to-unknown.test.ts
+++ b/src/lib/__tests__/error-any-to-unknown.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const files = {
+  insights: readFileSync(join(__dirname, '../../app/insights/page.tsx'), 'utf-8'),
+  budgetSuggestions: readFileSync(join(__dirname, '../../app/api/ai/budget-suggestions/route.ts'), 'utf-8'),
+  suggestAliases: readFileSync(join(__dirname, '../../app/api/ai/suggest-aliases/route.ts'), 'utf-8'),
+  anomalies: readFileSync(join(__dirname, '../../app/api/ai/anomalies/route.ts'), 'utf-8'),
+}
+
+describe('Replace error: any with error: unknown', () => {
+  for (const [name, source] of Object.entries(files)) {
+    it(`${name} does not use error: any or e: any`, () => {
+      expect(source).not.toContain(': any)')
+    })
+
+    it(`${name} uses instanceof Error guard`, () => {
+      expect(source).toContain('instanceof Error')
+    })
+  }
+
+  it('insights uses error: unknown for both catch blocks', () => {
+    const matches = files.insights.match(/catch \(e: unknown\)/g)
+    expect(matches).toHaveLength(2)
+  })
+
+  it('AI routes use error: unknown', () => {
+    expect(files.budgetSuggestions).toContain('catch (error: unknown)')
+    expect(files.suggestAliases).toContain('catch (error: unknown)')
+    expect(files.anomalies).toContain('catch (error: unknown)')
+  })
+})


### PR DESCRIPTION
## Summary
- Replaced `catch (e: any)` with `catch (e: unknown)` in `insights/page.tsx` (2 instances)
- Replaced `catch (error: any)` with `catch (error: unknown)` in three AI API routes: `budget-suggestions`, `suggest-aliases`, `anomalies`
- Added `instanceof Error` guards before accessing `.message` on caught errors

Closes #76

## Test plan
- [x] 10 new source-level tests verify no `: any)` patterns remain and `instanceof Error` guards exist
- [x] All 550 tests pass
- [x] Build passes