### PR TITLE
Add error handling to fetch calls in budgets and reconcile pages

### DIFF
--- a/src/app/budgets/page.tsx
+++ b/src/app/budgets/page.tsx
@@ -59,19 +59,22 @@ export default function BudgetsPage() {
   const fetchData = () => {
     setLoading(true)
     Promise.all([
-      fetch("/api/budgets").then((r) => r.json()),
-      fetch("/api/categories").then((r) => r.json()),
+      fetch("/api/budgets").then((r) => { if (!r.ok) throw new Error("Failed to load budgets"); return r.json() }),
+      fetch("/api/categories").then((r) => { if (!r.ok) throw new Error("Failed to load categories"); return r.json() }),
     ]).then(([budgetData, catData]) => {
       setBudgets(budgetData.budgets || [])
       setCategories(catData.categories || [])
-    }).finally(() => setLoading(false))
+    }).catch((err) => toast.error(err.message))
+      .finally(() => setLoading(false))
   }
 
   const fetchHistory = () => {
     setHistoryLoading(true)
-    fetch("/api/budgets/history").then(r => r.json()).then(d => {
-      setSpendingHistory(d.categories || [])
-    }).finally(() => setHistoryLoading(false))
+    fetch("/api/budgets/history")
+      .then(r => { if (!r.ok) throw new Error("Failed to load spending history"); return r.json() })
+      .then(d => { setSpendingHistory(d.categories || []) })
+      .catch((err) => toast.error(err.message))
+      .finally(() => setHistoryLoading(false))
   }
 
   useEffect(() => { fetchData(); fetchHistory() }, [])

--- a/src/app/reconcile/page.tsx
+++ b/src/app/reconcile/page.tsx
@@ -34,8 +34,14 @@ export default function ReconcilePage() {
   const [balanceError, setBalanceError] = useState<string | null>(null)
 
   useEffect(() => {
-    fetch("/api/accounts").then(r => r.json()).then(d => setAccounts(d.accounts || []))
-    fetch("/api/reconciliation").then(r => r.json()).then(d => setSessions(d.sessions || []))
+    fetch("/api/accounts")
+      .then(r => { if (!r.ok) throw new Error("Failed to load accounts"); return r.json() })
+      .then(d => setAccounts(d.accounts || []))
+      .catch(() => toast.error("Failed to load accounts"))
+    fetch("/api/reconciliation")
+      .then(r => { if (!r.ok) throw new Error("Failed to load sessions"); return r.json() })
+      .then(d => setSessions(d.sessions || []))
+      .catch(() => toast.error("Failed to load reconciliation sessions"))
   }, [])
 
   const startSession = async () => {
@@ -46,23 +52,33 @@ export default function ReconcilePage() {
       return
     }
     setBalanceError(null)
-    const res = await fetch("/api/reconciliation", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ account_id: accountId, statement_date: statementDate, statement_balance: parsed }),
-    })
-    const data = await res.json()
-    setActiveSession(data.session)
-    loadSessionTransactions(data.session.id)
-    toast.success("Reconciliation session started")
+    try {
+      const res = await fetch("/api/reconciliation", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ account_id: accountId, statement_date: statementDate, statement_balance: parsed }),
+      })
+      if (!res.ok) throw new Error("Failed to start reconciliation session")
+      const data = await res.json()
+      setActiveSession(data.session)
+      loadSessionTransactions(data.session.id)
+      toast.success("Reconciliation session started")
+    } catch {
+      toast.error("Failed to start reconciliation session")
+    }
   }
 
   const loadSessionTransactions = async (sessionId: string) => {
-    const res = await fetch(`/api/reconciliation/${sessionId}`)
-    const data = await res.json()
-    setTransactions(data.transactions || [])
-    setActiveSession(data.session)
-    setCleared(new Set(data.transactions?.filter((t: Transaction) => t.is_reconciled).map((t: Transaction) => t.id) || []))
+    try {
+      const res = await fetch(`/api/reconciliation/${sessionId}`)
+      if (!res.ok) throw new Error("Failed to load session")
+      const data = await res.json()
+      setTransactions(data.transactions || [])
+      setActiveSession(data.session)
+      setCleared(new Set(data.transactions?.filter((t: Transaction) => t.is_reconciled).map((t: Transaction) => t.id) || []))
+    } catch {
+      toast.error("Failed to load reconciliation transactions")
+    }
   }
 
   const toggleCleared = (id: string) => {
@@ -80,16 +96,24 @@ export default function ReconcilePage() {
 
   const finishReconciliation = async () => {
     if (!activeSession) return
-    await fetch(`/api/reconciliation/${activeSession.id}`, {
-      method: "PUT",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ status: "completed", clearedIds: Array.from(cleared) }),
-    })
-    setActiveSession(null)
-    setTransactions([])
-    setCleared(new Set())
-    fetch("/api/reconciliation").then(r => r.json()).then(d => setSessions(d.sessions || []))
-    toast.success("Reconciliation completed!")
+    try {
+      const res = await fetch(`/api/reconciliation/${activeSession.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ status: "completed", clearedIds: Array.from(cleared) }),
+      })
+      if (!res.ok) throw new Error("Failed to complete reconciliation")
+      setActiveSession(null)
+      setTransactions([])
+      setCleared(new Set())
+      fetch("/api/reconciliation")
+        .then(r => { if (!r.ok) throw new Error(); return r.json() })
+        .then(d => setSessions(d.sessions || []))
+        .catch(() => toast.error("Failed to refresh sessions"))
+      toast.success("Reconciliation completed!")
+    } catch {
+      toast.error("Failed to complete reconciliation")
+    }
   }
 
   const clearedBalance = transactions

--- a/src/lib/__tests__/budgets-reconcile-error-handling.test.ts
+++ b/src/lib/__tests__/budgets-reconcile-error-handling.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const budgetsSource = readFileSync(
+  join(__dirname, '../../app/budgets/page.tsx'),
+  'utf-8'
+)
+
+const reconcileSource = readFileSync(
+  join(__dirname, '../../app/reconcile/page.tsx'),
+  'utf-8'
+)
+
+describe('Budgets page error handling', () => {
+  it('checks response.ok in fetchData Promise.all', () => {
+    expect(budgetsSource).toContain('Failed to load budgets')
+    expect(budgetsSource).toContain('Failed to load categories')
+  })
+
+  it('has .catch() on the Promise.all chain', () => {
+    const fetchDataBlock = budgetsSource.slice(
+      budgetsSource.indexOf('const fetchData'),
+      budgetsSource.indexOf('const fetchHistory')
+    )
+    expect(fetchDataBlock).toContain('.catch(')
+  })
+
+  it('checks response.ok in fetchHistory', () => {
+    expect(budgetsSource).toContain('Failed to load spending history')
+  })
+
+  it('has .catch() on fetchHistory', () => {
+    const historyBlock = budgetsSource.slice(
+      budgetsSource.indexOf('const fetchHistory'),
+      budgetsSource.indexOf('useEffect(() => { fetchData')
+    )
+    expect(historyBlock).toContain('.catch(')
+  })
+})
+
+describe('Reconcile page error handling', () => {
+  it('checks response.ok for initial accounts fetch', () => {
+    expect(reconcileSource).toContain('Failed to load accounts')
+  })
+
+  it('checks response.ok for initial sessions fetch', () => {
+    expect(reconcileSource).toContain('Failed to load reconciliation sessions')
+  })
+
+  it('has error handling in startSession', () => {
+    const block = reconcileSource.slice(
+      reconcileSource.indexOf('const startSession'),
+      reconcileSource.indexOf('const loadSessionTransactions')
+    )
+    expect(block).toContain('if (!res.ok)')
+    expect(block).toContain('catch')
+  })
+
+  it('has error handling in loadSessionTransactions', () => {
+    const block = reconcileSource.slice(
+      reconcileSource.indexOf('const loadSessionTransactions'),
+      reconcileSource.indexOf('const toggleCleared')
+    )
+    expect(block).toContain('if (!res.ok)')
+    expect(block).toContain('catch')
+  })
+
+  it('has error handling in finishReconciliation', () => {
+    const block = reconcileSource.slice(
+      reconcileSource.indexOf('const finishReconciliation'),
+      reconcileSource.indexOf('const clearedBalance')
+    )
+    expect(block).toContain('if (!res.ok)')
+    expect(block).toContain('catch')
+  })
+})


### PR DESCRIPTION
## Summary
- **Budgets page**: `fetchData` (Promise.all) and `fetchHistory` now check `response.ok` and show toast errors on failure
- **Reconcile page**: All 5 fetch calls (initial loads, startSession, loadSessionTransactions, finishReconciliation) now check `response.ok` with try/catch and toast error feedback

Closes #77

## Test plan
- [x] 9 new source-level tests verify error handling patterns in both pages
- [x] All 549 tests pass
- [x] Build passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**Bug Fixes**
- Improved error handling for budget features with clear error notifications when data loads fail.
- Enhanced error handling for reconciliation operations with user-facing toast messages for failed requests.
- Fixed loading state management to reset properly after request failures.
- Failed operations now communicate errors to users instead of failing silently.

**Tests**
- Added test coverage for error-handling behavior in budgets and reconciliation features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->