### PR TITLE
Use shared safeParseJSON in rules-engine for malformed data

### DIFF
--- a/src/app/api/rules/route.ts
+++ b/src/app/api/rules/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { getDb } from '@/lib/db'
 import { applyRulesToTransactions } from '@/lib/rules-engine'
 import { validateBody, createRuleSchema, updateRuleSchema, deleteRuleSchema } from '@/lib/validation'
+import { safeParseJSON } from '@/lib/utils'
 
 interface RuleRow {
   id: string
@@ -14,14 +15,6 @@ interface RuleRow {
   created_at: string
   category_name: string | null
   category_icon: string | null
-}
-
-function safeParseJSON(json: string, fallback: unknown[] = []): unknown {
-  try {
-    return JSON.parse(json)
-  } catch {
-    return fallback
-  }
 }
 
 export async function GET() {

--- a/src/lib/__tests__/safe-parse-json.test.ts
+++ b/src/lib/__tests__/safe-parse-json.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+import { safeParseJSON } from '../utils'
+
+const rulesEngineSource = readFileSync(
+  join(__dirname, '../rules-engine.ts'),
+  'utf-8'
+)
+
+const rulesRouteSource = readFileSync(
+  join(__dirname, '../../app/api/rules/route.ts'),
+  'utf-8'
+)
+
+const utilsSource = readFileSync(
+  join(__dirname, '../utils.ts'),
+  'utf-8'
+)
+
+describe('safeParseJSON utility', () => {
+  it('parses valid JSON', () => {
+    expect(safeParseJSON('[1,2,3]')).toEqual([1, 2, 3])
+    expect(safeParseJSON('{"a":1}')).toEqual({ a: 1 })
+  })
+
+  it('returns fallback for malformed JSON', () => {
+    expect(safeParseJSON('not json')).toEqual([])
+    expect(safeParseJSON('{broken', ['default'])).toEqual(['default'])
+  })
+
+  it('returns fallback for empty string', () => {
+    expect(safeParseJSON('')).toEqual([])
+  })
+
+  it('is exported from utils.ts', () => {
+    expect(utilsSource).toContain('export function safeParseJSON')
+  })
+})
+
+describe('rules-engine.ts uses safeParseJSON', () => {
+  it('imports safeParseJSON from utils', () => {
+    expect(rulesEngineSource).toContain("import { safeParseJSON } from './utils'")
+  })
+
+  it('does not use raw JSON.parse for conditions/actions', () => {
+    expect(rulesEngineSource).not.toContain('JSON.parse(rule.conditions')
+    expect(rulesEngineSource).not.toContain('JSON.parse(rule.actions')
+  })
+
+  it('uses safeParseJSON for conditions and actions', () => {
+    expect(rulesEngineSource).toContain('safeParseJSON(rule.conditions')
+    expect(rulesEngineSource).toContain('safeParseJSON(rule.actions')
+  })
+
+  it('filters out rules with invalid parsed data', () => {
+    expect(rulesEngineSource).toContain('validRules')
+    expect(rulesEngineSource).toContain('Array.isArray(r.conditions)')
+    expect(rulesEngineSource).toContain('Array.isArray(r.actions)')
+  })
+})
+
+describe('rules route uses shared safeParseJSON', () => {
+  it('imports safeParseJSON from @/lib/utils', () => {
+    expect(rulesRouteSource).toContain("import { safeParseJSON } from '@/lib/utils'")
+  })
+
+  it('does not define its own safeParseJSON', () => {
+    expect(rulesRouteSource).not.toContain('function safeParseJSON')
+  })
+})

--- a/src/lib/rules-engine.ts
+++ b/src/lib/rules-engine.ts
@@ -1,4 +1,5 @@
 import { getDb } from './db'
+import { safeParseJSON } from './utils'
 
 export interface RuleCondition {
   field: 'description' | 'amount' | 'account'
@@ -87,11 +88,12 @@ export function applyRulesToTransactions(transactionIds?: string[]) {
 
   if (rules.length === 0) return { total: 0, matched: 0, ruleMatches: {} as Record<string, number> }
 
-  // Parse JSON fields
+  // Parse JSON fields — skip rules with malformed data
   for (const rule of rules) {
-    rule.conditions = JSON.parse(rule.conditions as unknown as string)
-    rule.actions = JSON.parse(rule.actions as unknown as string)
+    rule.conditions = safeParseJSON(rule.conditions as unknown as string) as RuleCondition[]
+    rule.actions = safeParseJSON(rule.actions as unknown as string) as RuleAction[]
   }
+  const validRules = rules.filter(r => Array.isArray(r.conditions) && Array.isArray(r.actions))
 
   let transactions: Transaction[]
   if (transactionIds) {
@@ -117,7 +119,7 @@ export function applyRulesToTransactions(transactionIds?: string[]) {
 
   const applyAll = db.transaction(() => {
     for (const txn of transactions) {
-      for (const rule of rules) {
+      for (const rule of validRules) {
         if (evaluateRule(rule, txn)) {
           for (const action of rule.actions) {
             switch (action.type) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -20,3 +20,11 @@ export function formatDate(date: string | Date): string {
 export function generateId(): string {
   return crypto.randomUUID()
 }
+
+export function safeParseJSON(json: string, fallback: unknown[] = []): unknown {
+  try {
+    return JSON.parse(json)
+  } catch {
+    return fallback
+  }
+}


### PR DESCRIPTION
## Summary
- Moved `safeParseJSON` from `rules/route.ts` to shared `src/lib/utils.ts`
- Replaced raw `JSON.parse` in `rules-engine.ts` with `safeParseJSON` — corrupted rules are now filtered out instead of crashing transaction processing
- Updated `rules/route.ts` to import from shared utils instead of defining its own copy

Closes #78

## Test plan
- [x] 10 new tests: 4 unit tests for `safeParseJSON` behavior, 4 source-level tests for rules-engine integration, 2 source-level tests for rules route
- [x] All 571 tests pass
- [x] Build passes