### PR TITLE
Use browser default locale for currency and date formatting

### DIFF
--- a/src/lib/__tests__/locale-formatting.test.ts
+++ b/src/lib/__tests__/locale-formatting.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const source = readFileSync(
+  join(__dirname, '../utils.ts'),
+  'utf-8'
+)
+
+describe('Locale-aware formatting', () => {
+  it('formatCurrency uses browser default locale (undefined) instead of en-US', () => {
+    expect(source).not.toContain("Intl.NumberFormat('en-US'")
+    expect(source).toContain('Intl.NumberFormat(undefined')
+  })
+
+  it('formatDate uses browser default locale (undefined) instead of en-US', () => {
+    expect(source).not.toContain("toLocaleDateString('en-US'")
+    expect(source).toContain('toLocaleDateString(undefined')
+  })
+
+  it('formatCurrency still accepts a currency parameter with USD default', () => {
+    expect(source).toContain("currency = 'USD'")
+  })
+
+  it('formatDate still accepts string or Date input', () => {
+    expect(source).toContain('date: string | Date')
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -6,7 +6,7 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function formatCurrency(amount: number, currency = 'USD'): string {
-  return new Intl.NumberFormat('en-US', {
+  return new Intl.NumberFormat(undefined, {
     style: 'currency',
     currency,
   }).format(amount)
@@ -14,7 +14,7 @@ export function formatCurrency(amount: number, currency = 'USD'): string {
 
 export function formatDate(date: string | Date): string {
   const d = typeof date === 'string' ? new Date(date) : date
-  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' })
+  return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })
 }
 
 export function generateId(): string {


### PR DESCRIPTION
## Summary
- `formatCurrency` and `formatDate` now use `undefined` locale (browser default) instead of hardcoded `en-US`
- Currency parameter still defaults to `'USD'` but displays in the user's locale format
- International users will see dates and currency in their local format

Closes #80

## Test plan
- [x] 4 new source-level tests verify locale changes
- [x] All 584 tests pass
- [x] Build passes