### PR TITLE
Add SQLite FTS5 index for transaction text search

### DIFF
--- a/src/lib/__tests__/fts5-search.test.ts
+++ b/src/lib/__tests__/fts5-search.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const dbSource = readFileSync(
+  join(__dirname, '../db.ts'),
+  'utf-8'
+)
+
+const filtersSource = readFileSync(
+  join(__dirname, '../transaction-filters.ts'),
+  'utf-8'
+)
+
+describe('FTS5 transaction search index', () => {
+  it('creates FTS5 virtual table for transactions', () => {
+    expect(dbSource).toContain('CREATE VIRTUAL TABLE IF NOT EXISTS transactions_fts USING fts5')
+  })
+
+  it('indexes raw_description, display_name, and notes', () => {
+    expect(dbSource).toContain("content='transactions'")
+    expect(dbSource).toContain('raw_description')
+    expect(dbSource).toContain('display_name')
+    expect(dbSource).toContain('notes')
+  })
+
+  it('has INSERT trigger to sync FTS on new transactions', () => {
+    expect(dbSource).toContain('CREATE TRIGGER IF NOT EXISTS transactions_ai AFTER INSERT ON transactions')
+  })
+
+  it('has DELETE trigger to sync FTS on removed transactions', () => {
+    expect(dbSource).toContain('CREATE TRIGGER IF NOT EXISTS transactions_ad AFTER DELETE ON transactions')
+  })
+
+  it('has UPDATE trigger to sync FTS on modified transactions', () => {
+    expect(dbSource).toContain('CREATE TRIGGER IF NOT EXISTS transactions_au AFTER UPDATE ON transactions')
+  })
+
+  it('rebuilds FTS index for existing data on init', () => {
+    expect(dbSource).toContain("INSERT INTO transactions_fts(transactions_fts) VALUES('rebuild')")
+  })
+})
+
+describe('Transaction filters use FTS5', () => {
+  it('uses FTS5 MATCH instead of LIKE for search', () => {
+    expect(filtersSource).toContain('transactions_fts MATCH')
+    expect(filtersSource).not.toContain('LIKE ?')
+  })
+
+  it('escapes double quotes in search terms', () => {
+    expect(filtersSource).toContain('replace(/"/g, \'""\')')
+  })
+})

--- a/src/lib/__tests__/transaction-filters.test.ts
+++ b/src/lib/__tests__/transaction-filters.test.ts
@@ -11,13 +11,11 @@ describe('buildTransactionFilters', () => {
     expect(result.params).toEqual([])
   })
 
-  it('builds search filter with LIKE on three columns', () => {
+  it('builds search filter with FTS5 MATCH', () => {
     const params = new URLSearchParams({ search: 'coffee' })
     const result = buildTransactionFilters(params)
-    expect(result.whereClause).toContain('t.raw_description LIKE ?')
-    expect(result.whereClause).toContain('t.display_name LIKE ?')
-    expect(result.whereClause).toContain('t.notes LIKE ?')
-    expect(result.params).toEqual(['%coffee%', '%coffee%', '%coffee%'])
+    expect(result.whereClause).toContain('transactions_fts MATCH ?')
+    expect(result.params).toEqual(['"coffee"'])
   })
 
   it('builds accountId filter', () => {
@@ -74,7 +72,7 @@ describe('buildTransactionFilters', () => {
     const params = new URLSearchParams({ search: 'food', accountId: 'acc-1', startDate: '2025-01-01' })
     const result = buildTransactionFilters(params)
     expect(result.whereClause).toMatch(/^WHERE .+ AND .+ AND .+$/)
-    expect(result.params.length).toBe(5) // 3 for search + 1 accountId + 1 date
+    expect(result.params.length).toBe(3) // 1 for FTS search + 1 accountId + 1 date
   })
 
   it('returns properly typed params (no any[])', () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -181,7 +181,39 @@ export function initializeSchema(db: Database.Database) {
     CREATE INDEX IF NOT EXISTS idx_merchant_aliases_pattern ON merchant_aliases(raw_pattern);
     CREATE INDEX IF NOT EXISTS idx_scheduled_bills_next_due ON scheduled_bills(next_due_date);
     CREATE INDEX IF NOT EXISTS idx_scheduled_bills_active ON scheduled_bills(is_active, next_due_date);
+
+    CREATE VIRTUAL TABLE IF NOT EXISTS transactions_fts USING fts5(
+      raw_description,
+      display_name,
+      notes,
+      content='transactions',
+      content_rowid='rowid'
+    );
+
+    CREATE TRIGGER IF NOT EXISTS transactions_ai AFTER INSERT ON transactions BEGIN
+      INSERT INTO transactions_fts(rowid, raw_description, display_name, notes)
+      VALUES (NEW.rowid, NEW.raw_description, NEW.display_name, NEW.notes);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS transactions_ad AFTER DELETE ON transactions BEGIN
+      INSERT INTO transactions_fts(transactions_fts, rowid, raw_description, display_name, notes)
+      VALUES ('delete', OLD.rowid, OLD.raw_description, OLD.display_name, OLD.notes);
+    END;
+
+    CREATE TRIGGER IF NOT EXISTS transactions_au AFTER UPDATE ON transactions BEGIN
+      INSERT INTO transactions_fts(transactions_fts, rowid, raw_description, display_name, notes)
+      VALUES ('delete', OLD.rowid, OLD.raw_description, OLD.display_name, OLD.notes);
+      INSERT INTO transactions_fts(rowid, raw_description, display_name, notes)
+      VALUES (NEW.rowid, NEW.raw_description, NEW.display_name, NEW.notes);
+    END;
   `)
+
+  // Rebuild FTS index from existing data (no-op if already populated)
+  const ftsCount = db.prepare('SELECT COUNT(*) as count FROM transactions_fts').get() as { count: number }
+  const txnCount = db.prepare('SELECT COUNT(*) as count FROM transactions').get() as { count: number }
+  if (ftsCount.count === 0 && txnCount.count > 0) {
+    db.exec(`INSERT INTO transactions_fts(transactions_fts) VALUES('rebuild')`)
+  }
 
   // Seed default categories if empty
   const count = db.prepare('SELECT COUNT(*) as count FROM categories').get() as { count: number }

--- a/src/lib/transaction-filters.ts
+++ b/src/lib/transaction-filters.ts
@@ -11,9 +11,10 @@ export function buildTransactionFilters(searchParams: URLSearchParams): {
 
   const search = searchParams.get('search')
   if (search) {
-    conditions.push('(t.raw_description LIKE ? OR t.display_name LIKE ? OR t.notes LIKE ?)')
-    const like = `%${search}%`
-    params.push(like, like, like)
+    // Use FTS5 for fast full-text search; escape double quotes in search term
+    const escaped = search.replace(/"/g, '""')
+    conditions.push('t.rowid IN (SELECT rowid FROM transactions_fts WHERE transactions_fts MATCH ?)')
+    params.push(`"${escaped}"`)
   }
 
   const accountId = searchParams.get('accountId')


### PR DESCRIPTION
## Summary
- Creates FTS5 virtual table (`transactions_fts`) indexed on `raw_description`, `display_name`, and `notes`
- Adds INSERT/UPDATE/DELETE triggers to keep FTS index in sync with transactions table
- Auto-rebuilds FTS index for existing data on first init
- Replaces `LIKE %search%` triple-column scan with single FTS5 `MATCH` query
- Escapes double quotes in search terms for safe FTS5 queries

Closes #79

## Test plan
- [x] 8 new source-level tests for FTS5 schema and filter changes
- [x] Updated 2 existing transaction-filters tests for new FTS5 pattern
- [x] All 592 tests pass
- [x] Build passes