### PR TITLE
Add light and dark mode support with theme toggle

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,11 +1,17 @@
 @import "tailwindcss";
 
 @theme {
-  --color-background: #09090b;
-  --color-foreground: #fafafa;
+  --color-background: #ffffff;
+  --color-foreground: #09090b;
 }
 
 :root {
+  color-scheme: light;
+}
+
+.dark {
+  --color-background: #09090b;
+  --color-foreground: #fafafa;
   color-scheme: dark;
 }
 
@@ -23,17 +29,17 @@ body {
 ::-webkit-scrollbar-track {
   background: transparent;
 }
-::-webkit-scrollbar-thumb {
+.dark ::-webkit-scrollbar-thumb {
   background: #3f3f46;
   border-radius: 3px;
 }
-::-webkit-scrollbar-thumb:hover {
+.dark ::-webkit-scrollbar-thumb:hover {
   background: #52525b;
 }
-
-/* Light mode */
-[data-theme="light"] {
-  --color-background: #ffffff;
-  --color-foreground: #09090b;
-  color-scheme: light;
+::-webkit-scrollbar-thumb {
+  background: #d4d4d8;
+  border-radius: 3px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: #a1a1aa;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "./globals.css"
 import { Sidebar } from "@/components/sidebar"
 import { ToastProvider } from "@/components/toast-provider"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { ThemeProvider } from "@/components/theme-provider"
 
 export const metadata: Metadata = {
   title: "CashFlow - Personal Finance",
@@ -11,23 +12,25 @@ export const metadata: Metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en" className="dark">
+    <html lang="en" suppressHydrationWarning>
       <body className="min-h-screen bg-background text-foreground antialiased">
-        <a
-          href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium"
-        >
-          Skip to main content
-        </a>
-        <Sidebar />
-        <main id="main-content" className="md:ml-64 min-h-screen">
-          <div className="p-6 md:p-8 max-w-7xl mx-auto">
-            <ErrorBoundary>
-              {children}
-            </ErrorBoundary>
-          </div>
-        </main>
-        <ToastProvider />
+        <ThemeProvider>
+          <a
+            href="#main-content"
+            className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:px-4 focus:py-2 focus:bg-blue-600 focus:text-white focus:rounded-lg focus:text-sm focus:font-medium"
+          >
+            Skip to main content
+          </a>
+          <Sidebar />
+          <main id="main-content" className="md:ml-64 min-h-screen">
+            <div className="p-6 md:p-8 max-w-7xl mx-auto">
+              <ErrorBoundary>
+                {children}
+              </ErrorBoundary>
+            </div>
+          </main>
+          <ToastProvider />
+        </ThemeProvider>
       </body>
     </html>
   )

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -14,9 +14,13 @@ import {
   CalendarClock,
   Menu,
   X,
+  Sun,
+  Moon,
+  Monitor,
 } from "lucide-react"
 import { cn } from "@/lib/utils"
-import { useState } from "react"
+import { useState, useEffect } from "react"
+import { useTheme } from "next-themes"
 
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: LayoutDashboard },
@@ -33,13 +37,17 @@ const navItems = [
 export function Sidebar() {
   const pathname = usePathname()
   const [mobileOpen, setMobileOpen] = useState(false)
+  const { theme, setTheme } = useTheme()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => setMounted(true), [])
 
   return (
     <>
       {/* Mobile toggle */}
       <button
         onClick={() => setMobileOpen(!mobileOpen)}
-        className="fixed top-4 left-4 z-50 md:hidden p-2 rounded-lg bg-zinc-800 text-zinc-300"
+        className="fixed top-4 left-4 z-50 md:hidden p-2 rounded-lg bg-zinc-200 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300"
         aria-label={mobileOpen ? "Close navigation menu" : "Open navigation menu"}
         aria-expanded={mobileOpen}
       >
@@ -57,12 +65,12 @@ export function Sidebar() {
       {/* Sidebar */}
       <aside
         className={cn(
-          "fixed left-0 top-0 z-40 h-screen w-64 bg-zinc-950 border-r border-zinc-800 flex flex-col transition-transform duration-200 md:translate-x-0",
+          "fixed left-0 top-0 z-40 h-screen w-64 bg-white dark:bg-zinc-950 border-r border-zinc-200 dark:border-zinc-800 flex flex-col transition-transform duration-200 md:translate-x-0",
           mobileOpen ? "translate-x-0" : "-translate-x-full"
         )}
       >
-        <div className="p-6 border-b border-zinc-800">
-          <h1 className="text-xl font-bold bg-gradient-to-r from-blue-400 to-emerald-400 bg-clip-text text-transparent">
+        <div className="p-6 border-b border-zinc-200 dark:border-zinc-800">
+          <h1 className="text-xl font-bold bg-gradient-to-r from-blue-500 to-emerald-500 dark:from-blue-400 dark:to-emerald-400 bg-clip-text text-transparent">
             CashFlow
           </h1>
           <p className="text-xs text-zinc-500 mt-1">Personal Finance</p>
@@ -80,8 +88,8 @@ export function Sidebar() {
                 className={cn(
                   "flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-colors",
                   isActive
-                    ? "bg-blue-600/10 text-blue-400 border border-blue-600/20"
-                    : "text-zinc-400 hover:text-zinc-200 hover:bg-zinc-800/50"
+                    ? "bg-blue-600/10 text-blue-600 dark:text-blue-400 border border-blue-600/20"
+                    : "text-zinc-500 dark:text-zinc-400 hover:text-zinc-900 dark:hover:text-zinc-200 hover:bg-zinc-100 dark:hover:bg-zinc-800/50"
                 )}
               >
                 <item.icon className="h-4 w-4" aria-hidden="true" />
@@ -91,8 +99,51 @@ export function Sidebar() {
           })}
         </nav>
 
-        <div className="p-4 border-t border-zinc-800">
-          <div className="text-xs text-zinc-600">Local-first. Your data stays yours.</div>
+        <div className="p-4 border-t border-zinc-200 dark:border-zinc-800 space-y-3">
+          {mounted && (
+            <div className="flex items-center gap-1 p-1 rounded-lg bg-zinc-100 dark:bg-zinc-800/50">
+              <button
+                onClick={() => setTheme("light")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium transition-colors",
+                  theme === "light"
+                    ? "bg-white dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 shadow-sm"
+                    : "text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                )}
+                aria-label="Light mode"
+              >
+                <Sun className="h-3.5 w-3.5" />
+                Light
+              </button>
+              <button
+                onClick={() => setTheme("dark")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium transition-colors",
+                  theme === "dark"
+                    ? "bg-white dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 shadow-sm"
+                    : "text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                )}
+                aria-label="Dark mode"
+              >
+                <Moon className="h-3.5 w-3.5" />
+                Dark
+              </button>
+              <button
+                onClick={() => setTheme("system")}
+                className={cn(
+                  "flex-1 flex items-center justify-center gap-1.5 px-2 py-1.5 rounded-md text-xs font-medium transition-colors",
+                  theme === "system"
+                    ? "bg-white dark:bg-zinc-700 text-zinc-900 dark:text-zinc-100 shadow-sm"
+                    : "text-zinc-500 hover:text-zinc-700 dark:hover:text-zinc-300"
+                )}
+                aria-label="System theme"
+              >
+                <Monitor className="h-3.5 w-3.5" />
+                Auto
+              </button>
+            </div>
+          )}
+          <div className="text-xs text-zinc-400 dark:text-zinc-600">Local-first. Your data stays yours.</div>
         </div>
       </aside>
     </>

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client"
+
+import { ThemeProvider as NextThemesProvider } from "next-themes"
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <NextThemesProvider attribute="class" defaultTheme="dark" enableSystem>
+      {children}
+    </NextThemesProvider>
+  )
+}

--- a/src/components/toast-provider.tsx
+++ b/src/components/toast-provider.tsx
@@ -1,19 +1,15 @@
 "use client"
 
 import { Toaster } from "sonner"
+import { useTheme } from "next-themes"
 
 export function ToastProvider() {
+  const { resolvedTheme } = useTheme()
+
   return (
     <Toaster
-      theme="dark"
+      theme={resolvedTheme === "dark" ? "dark" : "light"}
       position="bottom-right"
-      toastOptions={{
-        style: {
-          background: '#18181b',
-          border: '1px solid #27272a',
-          color: '#fafafa',
-        },
-      }}
     />
   )
 }

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -7,12 +7,12 @@ const badgeVariants = cva(
   {
     variants: {
       variant: {
-        default: "border-transparent bg-blue-600/20 text-blue-400",
-        secondary: "border-transparent bg-zinc-800 text-zinc-300",
-        destructive: "border-transparent bg-red-600/20 text-red-400",
-        success: "border-transparent bg-emerald-600/20 text-emerald-400",
-        warning: "border-transparent bg-amber-600/20 text-amber-400",
-        outline: "border-zinc-700 text-zinc-300",
+        default: "border-transparent bg-blue-600/20 text-blue-600 dark:text-blue-400",
+        secondary: "border-transparent bg-zinc-100 dark:bg-zinc-800 text-zinc-600 dark:text-zinc-300",
+        destructive: "border-transparent bg-red-600/20 text-red-600 dark:text-red-400",
+        success: "border-transparent bg-emerald-600/20 text-emerald-600 dark:text-emerald-400",
+        warning: "border-transparent bg-amber-600/20 text-amber-600 dark:text-amber-400",
+        outline: "border-zinc-300 dark:border-zinc-700 text-zinc-600 dark:text-zinc-300",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -10,10 +10,10 @@ const buttonVariants = cva(
       variant: {
         default: "bg-blue-600 text-white hover:bg-blue-700 shadow-sm",
         destructive: "bg-red-600 text-white hover:bg-red-700 shadow-sm",
-        outline: "border border-zinc-700 bg-transparent hover:bg-zinc-800 text-zinc-300",
-        secondary: "bg-zinc-800 text-zinc-300 hover:bg-zinc-700 shadow-sm",
-        ghost: "hover:bg-zinc-800 text-zinc-300",
-        link: "text-blue-400 underline-offset-4 hover:underline",
+        outline: "border border-zinc-300 dark:border-zinc-700 bg-transparent hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300",
+        secondary: "bg-zinc-100 dark:bg-zinc-800 text-zinc-700 dark:text-zinc-300 hover:bg-zinc-200 dark:hover:bg-zinc-700 shadow-sm",
+        ghost: "hover:bg-zinc-100 dark:hover:bg-zinc-800 text-zinc-700 dark:text-zinc-300",
+        link: "text-blue-600 dark:text-blue-400 underline-offset-4 hover:underline",
         success: "bg-emerald-600 text-white hover:bg-emerald-700 shadow-sm",
       },
       size: {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 
 const Card = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
   ({ className, ...props }, ref) => (
-    <div ref={ref} className={cn("rounded-xl border border-zinc-800 bg-zinc-900/50 text-zinc-100 shadow-lg", className)} {...props} />
+    <div ref={ref} className={cn("rounded-xl border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/50 text-zinc-900 dark:text-zinc-100 shadow-lg", className)} {...props} />
   )
 )
 Card.displayName = "Card"
@@ -24,7 +24,7 @@ CardTitle.displayName = "CardTitle"
 
 const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
   ({ className, ...props }, ref) => (
-    <p ref={ref} className={cn("text-sm text-zinc-400", className)} {...props} />
+    <p ref={ref} className={cn("text-sm text-zinc-500 dark:text-zinc-400", className)} {...props} />
   )
 )
 CardDescription.displayName = "CardDescription"

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -12,7 +12,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      "peer h-4 w-4 shrink-0 rounded border border-zinc-600 bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600",
+      "peer h-4 w-4 shrink-0 rounded border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-blue-600 data-[state=checked]:border-blue-600",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -31,13 +31,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 w-full max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] gap-4 border border-zinc-800 bg-zinc-900 p-6 shadow-2xl rounded-xl grid",
+        "fixed left-[50%] top-[50%] z-50 w-full max-w-lg max-h-[85vh] translate-x-[-50%] translate-y-[-50%] gap-4 border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-zinc-900 p-6 shadow-2xl rounded-xl grid",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 text-zinc-400" aria-label="Close">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 hover:opacity-100 text-zinc-500 dark:text-zinc-400" aria-label="Close">
         <X className="h-4 w-4" aria-hidden="true" />
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
@@ -53,7 +53,7 @@ const DialogTitle = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-zinc-100", className)} {...props} />
+  <DialogPrimitive.Title ref={ref} className={cn("text-lg font-semibold text-zinc-900 dark:text-zinc-100", className)} {...props} />
 ))
 DialogTitle.displayName = DialogPrimitive.Title.displayName
 
@@ -61,7 +61,7 @@ const DialogDescription = React.forwardRef<
   React.ComponentRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-zinc-400", className)} {...props} />
+  <DialogPrimitive.Description ref={ref} className={cn("text-sm text-zinc-500 dark:text-zinc-400", className)} {...props} />
 ))
 DialogDescription.displayName = DialogPrimitive.Description.displayName
 

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -6,7 +6,7 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
     <input
       type={type}
       className={cn(
-        "flex h-10 w-full rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 py-2 text-sm text-zinc-100 placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:cursor-not-allowed disabled:opacity-50",
+        "flex h-10 w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -16,7 +16,7 @@ const Progress = React.forwardRef<HTMLDivElement, ProgressProps>(
         aria-valuenow={Math.round(clampedValue)}
         aria-valuemin={0}
         aria-valuemax={100}
-        className={cn("relative h-3 w-full overflow-hidden rounded-full bg-zinc-800", className)}
+        className={cn("relative h-3 w-full overflow-hidden rounded-full bg-zinc-200 dark:bg-zinc-800", className)}
         {...props}
       >
         <div

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,7 +6,7 @@ const Select = React.forwardRef<HTMLSelectElement, React.SelectHTMLAttributes<HT
     <select
       ref={ref}
       className={cn(
-        "flex h-10 w-full rounded-lg border border-zinc-700 bg-zinc-800/50 px-3 py-2 text-sm text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:cursor-not-allowed disabled:opacity-50 appearance-none",
+        "flex h-10 w-full rounded-lg border border-zinc-300 dark:border-zinc-700 bg-white dark:bg-zinc-800/50 px-3 py-2 text-sm text-zinc-900 dark:text-zinc-100 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent disabled:cursor-not-allowed disabled:opacity-50 appearance-none",
         className
       )}
       {...props}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -3,7 +3,7 @@ import { cn } from "@/lib/utils"
 function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn("animate-pulse rounded-md bg-zinc-800", className)}
+      className={cn("animate-pulse rounded-md bg-zinc-200 dark:bg-zinc-800", className)}
       {...props}
     />
   )

--- a/src/lib/__tests__/theme-support.test.ts
+++ b/src/lib/__tests__/theme-support.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { join } from 'path'
+
+const layoutSource = readFileSync(join(__dirname, '../../app/layout.tsx'), 'utf-8')
+const sidebarSource = readFileSync(join(__dirname, '../../components/sidebar.tsx'), 'utf-8')
+const themeProviderSource = readFileSync(join(__dirname, '../../components/theme-provider.tsx'), 'utf-8')
+const toastProviderSource = readFileSync(join(__dirname, '../../components/toast-provider.tsx'), 'utf-8')
+const globalsCss = readFileSync(join(__dirname, '../../app/globals.css'), 'utf-8')
+
+describe('Theme provider setup', () => {
+  it('ThemeProvider wraps next-themes with class attribute', () => {
+    expect(themeProviderSource).toContain('attribute="class"')
+    expect(themeProviderSource).toContain('defaultTheme="dark"')
+    expect(themeProviderSource).toContain('enableSystem')
+  })
+
+  it('layout.tsx uses ThemeProvider', () => {
+    expect(layoutSource).toContain('<ThemeProvider>')
+    expect(layoutSource).toContain('import { ThemeProvider }')
+  })
+
+  it('layout.tsx does not hardcode dark class on html', () => {
+    expect(layoutSource).not.toContain('className="dark"')
+    expect(layoutSource).toContain('suppressHydrationWarning')
+  })
+})
+
+describe('CSS supports both themes', () => {
+  it('defines light mode variables as default', () => {
+    expect(globalsCss).toContain('--color-background: #ffffff')
+    expect(globalsCss).toContain('--color-foreground: #09090b')
+  })
+
+  it('defines dark mode variables in .dark class', () => {
+    expect(globalsCss).toContain('.dark {')
+    expect(globalsCss).toContain('--color-background: #09090b')
+    expect(globalsCss).toContain('--color-foreground: #fafafa')
+  })
+})
+
+describe('Sidebar theme toggle', () => {
+  it('imports useTheme from next-themes', () => {
+    expect(sidebarSource).toContain("import { useTheme } from \"next-themes\"")
+  })
+
+  it('has light, dark, and system theme buttons', () => {
+    expect(sidebarSource).toContain('setTheme("light")')
+    expect(sidebarSource).toContain('setTheme("dark")')
+    expect(sidebarSource).toContain('setTheme("system")')
+  })
+
+  it('imports Sun, Moon, and Monitor icons', () => {
+    expect(sidebarSource).toContain('Sun')
+    expect(sidebarSource).toContain('Moon')
+    expect(sidebarSource).toContain('Monitor')
+  })
+
+  it('uses dark: prefixes for theme-aware sidebar colors', () => {
+    expect(sidebarSource).toContain('dark:bg-zinc-950')
+    expect(sidebarSource).toContain('dark:border-zinc-800')
+  })
+})
+
+describe('Toast provider is theme-aware', () => {
+  it('uses resolvedTheme from next-themes', () => {
+    expect(toastProviderSource).toContain('useTheme')
+    expect(toastProviderSource).toContain('resolvedTheme')
+  })
+
+  it('does not hardcode dark theme', () => {
+    expect(toastProviderSource).not.toContain('theme="dark"')
+  })
+})
+
+describe('UI components support both themes', () => {
+  const components = {
+    card: readFileSync(join(__dirname, '../../components/ui/card.tsx'), 'utf-8'),
+    input: readFileSync(join(__dirname, '../../components/ui/input.tsx'), 'utf-8'),
+    select: readFileSync(join(__dirname, '../../components/ui/select.tsx'), 'utf-8'),
+    dialog: readFileSync(join(__dirname, '../../components/ui/dialog.tsx'), 'utf-8'),
+    button: readFileSync(join(__dirname, '../../components/ui/button.tsx'), 'utf-8'),
+    badge: readFileSync(join(__dirname, '../../components/ui/badge.tsx'), 'utf-8'),
+    skeleton: readFileSync(join(__dirname, '../../components/ui/skeleton.tsx'), 'utf-8'),
+  }
+
+  for (const [name, source] of Object.entries(components)) {
+    it(`${name} uses dark: prefixes`, () => {
+      expect(source).toContain('dark:')
+    })
+  }
+})


### PR DESCRIPTION
## Summary
- Integrates `next-themes` (already installed) with `attribute="class"` strategy
- Adds `ThemeProvider` component wrapping the app, removing hardcoded `dark` class from `<html>`
- Adds 3-way theme toggle (Light / Dark / Auto) to sidebar footer
- Updates all 9 UI components with `dark:` prefixes: card, button, badge, input, select, dialog, checkbox, skeleton, progress
- Toast provider now uses `resolvedTheme` to match the active theme
- CSS updated: light mode as default, dark mode in `.dark` class
- Defaults to dark mode, supports system preference with Auto

Closes #87

## Test plan
- [x] 18 new source-level tests verify theme provider setup, CSS variables, sidebar toggle, toast provider, and UI component dark: prefixes
- [x] All 602 tests pass
- [x] Build passes